### PR TITLE
Minor updates/fixes for latest versions of external code

### DIFF
--- a/cfecfs/testexecutive/src/testctrl.c
+++ b/cfecfs/testexecutive/src/testctrl.c
@@ -46,7 +46,7 @@
 /*
 **  volume table.
 */
-OS_VolumeInfo_t OS_VolumeTable [NUM_TABLE_ENTRIES] =
+OS_VolumeInfo_t OS_VolumeTable [OS_MAX_FILE_SYSTEMS] =
 {
         /*
          ** The following entry is a "pre-mounted" path to a non-volatile device

--- a/cfecfs/testexecutive/src/testexec.c
+++ b/cfecfs/testexecutive/src/testexec.c
@@ -62,7 +62,7 @@ typedef struct
 /*
 **  volume table.
 */
-OS_VolumeInfo_t OS_VolumeTable [NUM_TABLE_ENTRIES] =
+OS_VolumeInfo_t OS_VolumeTable [OS_MAX_FILE_SYSTEMS] =
 {
         /*
          ** The following entry is a "pre-mounted" path to a non-volatile device

--- a/edslib/python/CMakeLists.txt
+++ b/edslib/python/CMakeLists.txt
@@ -154,6 +154,7 @@ else ()
         add_library(edslib_python_module MODULE
             src/edslib_python_module.c
             $<TARGET_OBJECTS:edslib_python_pic>
+            $<TARGET_OBJECTS:edslib_runtime_pic>
         )
 
         # Per Python naming conventions, the output file should be called only "EdsLib"

--- a/edslib/python/src/edslib_python_base.c
+++ b/edslib/python/src/edslib_python_base.c
@@ -106,6 +106,8 @@
 
 #include "edslib_python_internal.h"
 
+static char         EDSLIB_PYTHON_BYTES_FORMAT[] = "B";
+
 static void         EdsLib_Python_ObjectBase_dealloc(PyObject * obj);
 static int          EdsLib_Python_ObjectBase_init(PyObject *obj, PyObject *args, PyObject *kwds);
 static PyObject *   EdsLib_Python_ObjectBase_repr(PyObject *obj);
@@ -583,7 +585,7 @@ static int EdsLib_Python_ObjectBase_getbuffer(PyObject *obj, Py_buffer *view, in
     view->itemsize = 1;
     if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT)
     {
-        view->format = "B";
+        view->format = EDSLIB_PYTHON_BYTES_FORMAT;
     }
     if ((flags & PyBUF_ND) == PyBUF_ND)
     {

--- a/edslib/python/src/edslib_python_container.c
+++ b/edslib/python/src/edslib_python_container.c
@@ -90,7 +90,7 @@ PyTypeObject EdsLib_Python_ContainerIteratorType =
 static void EdsLib_Python_ContainerIterator_dealloc(PyObject * obj)
 {
     EdsLib_Python_ContainerIterator_t *self = (EdsLib_Python_ContainerIterator_t*)obj;
-    _PyObject_GC_UNTRACK(self);
+    PyObject_GC_UnTrack(self);
     Py_XDECREF(self->refobj);
     PyObject_GC_Del(self);
 }
@@ -321,7 +321,7 @@ static PyObject *   EdsLib_Python_ObjectContainer_iter(PyObject *obj)
     result->Position = 0;
     Py_INCREF(obj);
     result->refobj = obj;
-    _PyObject_GC_TRACK(result);
+    PyObject_GC_Track(result);
 
     return (PyObject*)result;
 }


### PR DESCRIPTION
Corrects some minor issues found when building with the newer versions of CFE and Python

- OSAL symbol NUM_TABLE_ENTRIES replaced with OS_MAX_FILE_SYSTEMS
- _PyObject_GC_UNTRACK macro deprecated in Python 3.8
- Avoid compiler warning about "const" literal.
- Correct linking issue with EdsLib python module