### PR TITLE
Python modules

### DIFF
--- a/cfecfs/missionlib/fsw/CMakeLists.txt
+++ b/cfecfs/missionlib/fsw/CMakeLists.txt
@@ -130,6 +130,20 @@ set_target_properties(cfe_missionlib PROPERTIES
     COMPILE_DEFINITIONS "_EDSLIB_BUILD_"
 )
 
+# CFE_MissionLib pic libraries
+add_library(cfe_missionlib_pic STATIC EXCLUDE_FROM_ALL
+    src/cfe_missionlib_api.c
+)
+set_target_properties(cfe_missionlib_pic PROPERTIES 
+    POSITION_INDEPENDENT_CODE TRUE COMPILE_DEFINITIONS "_EDSLIB_BUILD_")
+
+add_library(cfe_missionlib_runtime_pic STATIC EXCLUDE_FROM_ALL
+    src/cfe_missionlib_api.c
+    ${RUNTIME_SOURCE}
+)
+set_target_properties(cfe_missionlib_runtime_pic PROPERTIES 
+    POSITION_INDEPENDENT_CODE TRUE COMPILE_DEFINITIONS "_EDSLIB_BUILD_")
+
 if (ENABLE_UNIT_TESTS)
   add_subdirectory(ut-stubs)
 endif (ENABLE_UNIT_TESTS)

--- a/cfecfs/missionlib/fsw/src/cfe_missionlib_api.c
+++ b/cfecfs/missionlib/fsw/src/cfe_missionlib_api.c
@@ -244,6 +244,7 @@ int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interfa
     {
         Status = CFE_MISSIONLIB_SUCCESS;
         IntfInfo->NumCommands = Intf->InterfaceList[InterfaceId-1].NumCommands;
+        IntfInfo->NumTopics = Intf->InterfaceList[InterfaceId-1].NumTopics;
     }
 
     return Status;
@@ -404,7 +405,7 @@ const char *CFE_MissionLib_GetTopicName(const CFE_MissionLib_SoftwareBus_Interfa
     }
 
     TopicPtr = CFE_MissionLib_Lookup_Topic(IntfPtr, TopicId);
-    if (TopicPtr == NULL)
+    if ((TopicPtr == NULL) || (TopicPtr->InterfaceId != InterfaceType))
     {
         return NULL;
     }

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
@@ -64,9 +64,9 @@ static PyObject *   CFE_MissionLib_Python_InstanceIterator_iternext(PyObject *ob
 
 static PyMethodDef CFE_MissionLib_Python_Database_methods[] =
 {
-		{"Interface",  CFE_MissionLib_Python_Database_GetInterface, METH_O, "Lookup an Interface type from DB."},
-		{"DecodeEdsId", CFE_MissionLib_Python_DecodeEdsId, METH_VARARGS, "Decode the EdsID from a packed cFE message"},
-		{"SetPubSub", CFE_MissionLib_Python_Set_PubSub, METH_VARARGS, "Set the PubSub parameters for a command message"},
+        {"Interface",  CFE_MissionLib_Python_Database_GetInterface, METH_O, "Lookup an Interface type from DB."},
+        {"DecodeEdsId", CFE_MissionLib_Python_DecodeEdsId, METH_VARARGS, "Decode the EdsID from a packed cFE message"},
+        {"SetPubSub", CFE_MissionLib_Python_Set_PubSub, METH_VARARGS, "Set the PubSub parameters for a command message"},
         {NULL}  /* Sentinel */
 };
 
@@ -89,7 +89,7 @@ PyTypeObject CFE_MissionLib_Python_DatabaseType =
     .tp_repr = CFE_MissionLib_Python_Database_repr,
     .tp_traverse = CFE_MissionLib_Python_Database_traverse,
     .tp_clear = CFE_MissionLib_Python_Database_clear,
-	.tp_iter = CFE_MissionLib_Python_Instance_iter,
+    .tp_iter = CFE_MissionLib_Python_Instance_iter,
     .tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC,
     .tp_weaklistoffset = offsetof(CFE_MissionLib_Python_Database_t, WeakRefList),
     .tp_doc = PyDoc_STR("Interface database")
@@ -107,7 +107,7 @@ PyTypeObject CFE_MissionLib_Python_InstanceIteratorType =
     .tp_clear = CFE_MissionLib_Python_InstanceIterator_clear,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = CFE_MissionLib_Python_InstanceIterator_iternext,
-	.tp_doc = PyDoc_STR("CFE MissionLib InterfaceIteratorType")
+    .tp_doc = PyDoc_STR("CFE MissionLib InstanceIteratorType")
 };
 
 static int CFE_MissionLib_Python_Database_traverse(PyObject *obj, visitproc visit, void *arg)
@@ -243,11 +243,11 @@ const CFE_MissionLib_SoftwareBus_Interface_t *CFE_MissionLib_Python_Database_Get
 
 static PyObject *CFE_MissionLib_Python_Database_new(PyTypeObject *obj, PyObject *args, PyObject *kwds)
 {
-	PyObject *arg1;
-	PyObject *arg2;
+    PyObject *arg1;
+    PyObject *arg2;
 
-	PyObject *tempargs;
-	const char *dbstr;
+    PyObject *tempargs;
+    const char *dbstr;
     PyObject *nameobj;
     char *p;
     char tempstring[512];
@@ -377,7 +377,7 @@ static PyObject *CFE_MissionLib_Python_Database_GetInterface(PyObject *obj, PyOb
 static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args)
 {
     CFE_MissionLib_Python_Database_t *IntfDb = (CFE_MissionLib_Python_Database_t *)obj;
-	PyObject *arg1;
+    PyObject *arg1;
     EdsLib_Python_Database_t *EdsDb;
 
     Py_ssize_t BytesSize;
@@ -388,17 +388,17 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
     CFE_SB_Publisher_Component_t PublisherParams;
     CFE_SB_Listener_Component_t ListenerParams;
 
-	EdsLib_Id_t EdsId;
-	uint16_t TopicId;
-	EdsLib_DataTypeDB_TypeInfo_t TypeInfo;
-	int32_t Status;
+    EdsLib_Id_t EdsId;
+    uint16_t TopicId;
+    EdsLib_DataTypeDB_TypeInfo_t TypeInfo;
+    int32_t Status;
 
-	PyObject *result = NULL;
+    PyObject *result = NULL;
 
     if (!PyArg_UnpackTuple(args, "DecodeEdsId", 1, 1, &arg1))
     {
         PyErr_Format(PyExc_RuntimeError, "encoded bytes string argument expected");
-    	return NULL;
+        return NULL;
     }
 
     Py_INCREF(arg1);
@@ -435,23 +435,23 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
 
         if (CFE_SB_PubSub_IsPublisherComponent(&PubSubParams))
         {
-			CFE_SB_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
-			TopicId = PublisherParams.Telemetry.TopicId;
+            CFE_SB_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
+            TopicId = PublisherParams.Telemetry.TopicId;
 
-			Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telemetry_Interface_ID,
-					PublisherParams.Telemetry.TopicId, 1, 1, &EdsId);
+            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telemetry_Interface_ID,
+                    PublisherParams.Telemetry.TopicId, 1, 1, &EdsId);
         }
         else if (CFE_SB_PubSub_IsListenerComponent(&PubSubParams))
         {
-        	CFE_SB_UnmapListenerComponent(&ListenerParams, &PubSubParams);
-			TopicId = ListenerParams.Telecommand.TopicId;
+            CFE_SB_UnmapListenerComponent(&ListenerParams, &PubSubParams);
+            TopicId = ListenerParams.Telecommand.TopicId;
 
-        	Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telecommand_Interface_ID,
-        			ListenerParams.Telecommand.TopicId, 1, 1, &EdsId);
+            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telecommand_Interface_ID,
+                    ListenerParams.Telecommand.TopicId, 1, 1, &EdsId);
         }
         else
         {
-        	Status = CFE_MISSIONLIB_INVALID_INTERFACE;
+            Status = CFE_MISSIONLIB_INVALID_INTERFACE;
         }
 
         if (Status != CFE_MISSIONLIB_SUCCESS)
@@ -460,8 +460,9 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
     	    break;
         }
 
-        //result = PyLong_FromLong((long int)EdsId);
-        result = PyTuple_Pack(2, PyLong_FromLong((long int)EdsId), PyLong_FromLong((long int) TopicId));
+        result = PyTuple_New(2);
+        PyTuple_SetItem(result, 0, PyLong_FromLong((long int) EdsId));
+        PyTuple_SetItem(result, 1, PyLong_FromLong((long int) TopicId));
     }
     while(0);
 
@@ -476,6 +477,7 @@ static PyObject *  CFE_MissionLib_Python_Set_PubSub(PyObject *obj, PyObject *arg
     PyObject *arg2;
     PyObject *arg3;
     PyObject *tempargs;
+    PyObject *result = NULL;
 
     EdsLib_Python_ObjectBase_t *Python_Packet;
     EdsLib_Python_Buffer_t *StorageBuffer;
@@ -490,6 +492,7 @@ static PyObject *  CFE_MissionLib_Python_Set_PubSub(PyObject *obj, PyObject *arg
         PyErr_Format(PyExc_RuntimeError, "Arguments expected: InstanceNumber, TopicId, and SpacePacket Message");
     	return Py_False;
     }
+
     Py_INCREF(arg1);
     Py_INCREF(arg2);
     Py_INCREF(arg3);
@@ -498,49 +501,48 @@ static PyObject *  CFE_MissionLib_Python_Set_PubSub(PyObject *obj, PyObject *arg
     {
     	if (PyNumber_Check(arg1))
     	{
-    		tempargs = PyNumber_Long(arg1);
-    		Py_INCREF(tempargs);
+            tempargs = PyNumber_Long(arg1);
 
-    		Params.Telecommand.InstanceNumber = PyLong_AsUnsignedLong(tempargs);
-    		Py_DECREF(tempargs);
+            Params.Telecommand.InstanceNumber = PyLong_AsUnsignedLong(tempargs);
+            Py_DECREF(tempargs);
     	}
     	else
     	{
-    		PyErr_Format(PyExc_RuntimeError, "InstanceNumber needs to be an integer");
-    		return Py_False;
+            PyErr_Format(PyExc_RuntimeError, "InstanceNumber needs to be an integer");
+            break;
     	}
 
+        if (PyNumber_Check(arg2))
+        {
+            tempargs = PyNumber_Long(arg2);
 
-    	if (PyNumber_Check(arg2))
+            Params.Telecommand.TopicId = PyLong_AsUnsignedLong(tempargs);
+            Py_DECREF(tempargs);
+        }
+        else
     	{
-    		tempargs = PyNumber_Long(arg2);
-    		Py_INCREF(tempargs);
-
-    		Params.Telecommand.TopicId = PyLong_AsUnsignedLong(tempargs);
-    		Py_DECREF(tempargs);
-    	}
-    	else
-    	{
-    		PyErr_Format(PyExc_RuntimeError, "InstanceNumber neesd to be an integer");
-    		return Py_False;
+            PyErr_Format(PyExc_RuntimeError, "TopicId needs to be an integer");
+            break;
     	}
 
     	// Dive through an EdsLib python base object to get to the actual EDS data
-    	Python_Packet = (EdsLib_Python_ObjectBase_t *) arg3;
-    	StorageBuffer = Python_Packet->StorageBuf;
-    	edsbuf = StorageBuffer->edsbuf;
-    	Packet = (CCSDS_SpacePacket_t *) edsbuf.Data;
+        Python_Packet = (EdsLib_Python_ObjectBase_t *) arg3;
+        StorageBuffer = Python_Packet->StorageBuf;
+        edsbuf = StorageBuffer->edsbuf;
+        Packet = (CCSDS_SpacePacket_t *) edsbuf.Data;
 
-    	CFE_SB_MapListenerComponent(&PubSub, &Params);
-    	CFE_SB_Set_PubSub_Parameters(Packet, &PubSub);
+        CFE_SB_MapListenerComponent(&PubSub, &Params);
+        CFE_SB_Set_PubSub_Parameters(Packet, &PubSub);
 
+        Py_INCREF(Py_True);
+        result = Py_True;
     } while(0);
 
     Py_XDECREF(arg1);
     Py_XDECREF(arg2);
     Py_XDECREF(arg3);
 
-    return Py_True;
+    return result;
 }
 
 static PyObject *  CFE_MissionLib_Python_Instance_iter(PyObject *obj)
@@ -552,7 +554,7 @@ static PyObject *  CFE_MissionLib_Python_Instance_iter(PyObject *obj)
 
     if (InstIter == NULL)
     {
-    	return NULL;
+        return NULL;
     }
 
     Py_INCREF(obj);
@@ -589,8 +591,8 @@ static int CFE_MissionLib_Python_InstanceIterator_clear(PyObject *obj)
 
 static PyObject *CFE_MissionLib_Python_InstanceIterator_iternext(PyObject *obj)
 {
-	CFE_MissionLib_Python_InstanceIterator_t *self = (CFE_MissionLib_Python_InstanceIterator_t*)obj;
-	CFE_MissionLib_Python_Database_t *dbobj = NULL;
+    CFE_MissionLib_Python_InstanceIterator_t *self = (CFE_MissionLib_Python_InstanceIterator_t*)obj;
+    CFE_MissionLib_Python_Database_t *dbobj = NULL;
     const char * Label = NULL;
     char Buffer[64];
     char CheckBuffer[64];
@@ -614,14 +616,12 @@ static PyObject *CFE_MissionLib_Python_InstanceIterator_iternext(PyObject *obj)
         snprintf(CheckBuffer, sizeof(CheckBuffer), "%u", (unsigned int) self->Index);
         if (strcmp(Label,CheckBuffer) == 0)
         {
-        	break;
+            break;
         }
 
         key = PyUnicode_FromString(Label);
-        Py_INCREF(key);
 
         instanceid = PyLong_FromLong((long int)self->Index);
-        Py_INCREF(instanceid);
 
         ++self->Index;
         result = PyTuple_Pack(2, key, instanceid);

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_interface.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_interface.c
@@ -59,7 +59,7 @@ static CFE_MissionLib_Python_Interface_t *CFE_MissionLib_Python_Interface_GetFro
 static PyMethodDef CFE_MissionLib_Python_Interface_methods[] =
 {
         {"Topic",  CFE_MissionLib_Python_Interface_gettopic, METH_O, "Lookup a Topic from an Interface."},
-		{"GetCmdMessage", CFE_MissionLib_Python_Interface_GetCmdMessage, METH_VARARGS, "Get a CFE command message EDS Object from a Topic"},
+        {"GetCmdMessage", CFE_MissionLib_Python_Interface_GetCmdMessage, METH_VARARGS, "Get a CFE command message EDS Object from a Topic"},
         {NULL}  /* Sentinel */
 };
 
@@ -85,7 +85,7 @@ PyTypeObject CFE_MissionLib_Python_InterfaceType =
     .tp_iter = CFE_MissionLib_Python_Interface_iter,
     .tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC,
     .tp_weaklistoffset = offsetof(CFE_MissionLib_Python_Interface_t, WeakRefList),
-    .tp_doc = "Interface database entry"
+    .tp_doc = PyDoc_STR("Interface database entry")
 };
 
 PyTypeObject CFE_MissionLib_Python_InterfaceIteratorType =
@@ -100,7 +100,7 @@ PyTypeObject CFE_MissionLib_Python_InterfaceIteratorType =
     .tp_clear = CFE_MissionLib_Python_InterfaceIterator_clear,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = CFE_MissionLib_Python_InterfaceIterator_iternext,
-	.tp_doc = PyDoc_STR("CFE MissionLib InterfaceIteratorType")
+    .tp_doc = PyDoc_STR("CFE MissionLib InterfaceIteratorType")
 };
 
 static int CFE_MissionLib_Python_Interface_traverse(PyObject *obj, visitproc visit, void *arg)
@@ -109,6 +109,7 @@ static int CFE_MissionLib_Python_Interface_traverse(PyObject *obj, visitproc vis
     Py_VISIT(self->DbObj);
     Py_VISIT(self->IntfName);
     Py_VISIT(self->TypeCache);
+
     return 0;
 }
 
@@ -118,6 +119,7 @@ static int CFE_MissionLib_Python_Interface_clear(PyObject *obj)
     Py_CLEAR(self->DbObj);
     Py_CLEAR(self->IntfName);
     Py_CLEAR(self->TypeCache);
+
     return 0;
 }
 
@@ -266,22 +268,22 @@ static PyObject *CFE_MissionLib_Python_Interface_new(PyTypeObject *obj, PyObject
         }
         else
         {
-        	if (arg3 != NULL)
-        	{
-        		tempargs = PyTuple_Pack(2, arg1, arg3);
-        	}
-        	else
-        	{
-        		tempargs = PyTuple_Pack(2, arg1, Py_None);
-        	}
+            if (arg3 != NULL)
+            {
+                tempargs = PyTuple_Pack(2, arg1, arg3);
+            }
+            else
+            {
+                tempargs = PyTuple_Pack(2, arg1, Py_None);
+            }
 
-        	if (tempargs == NULL)
-        	{
-        		break;
-        	}
-        	DbObj = (CFE_MissionLib_Python_Database_t*)PyObject_Call((PyObject*)&CFE_MissionLib_Python_DatabaseType, tempargs, NULL);
-        	Py_DECREF(tempargs);
-        	tempargs = NULL;
+            if (tempargs == NULL)
+            {
+                break;
+            }
+            DbObj = (CFE_MissionLib_Python_Database_t*)PyObject_Call((PyObject*)&CFE_MissionLib_Python_DatabaseType, tempargs, NULL);
+            Py_DECREF(tempargs);
+            tempargs = NULL;
         }
 
         if (DbObj == NULL)
@@ -384,29 +386,29 @@ PyObject *CFE_MissionLib_Python_Interface_GetFromIntfName(CFE_MissionLib_Python_
 static PyObject *  CFE_MissionLib_Python_Interface_iter(PyObject *obj)
 {
     CFE_MissionLib_Python_Interface_t *Intf = (CFE_MissionLib_Python_Interface_t *) obj;
-	CFE_MissionLib_Python_InterfaceIterator_t *IntfIter;
-	PyObject *result = NULL;
+    CFE_MissionLib_Python_InterfaceIterator_t *IntfIter;
+    PyObject *result = NULL;
 
-	if (Intf->IntfInfo.NumTopics != 0)
-	{
-    	IntfIter = PyObject_GC_New(CFE_MissionLib_Python_InterfaceIterator_t, &CFE_MissionLib_Python_InterfaceIteratorType);
+    if (Intf->IntfInfo.NumTopics != 0)
+    {
+        IntfIter = PyObject_GC_New(CFE_MissionLib_Python_InterfaceIterator_t, &CFE_MissionLib_Python_InterfaceIteratorType);
 
-    	if (IntfIter == NULL)
-    	{
-    		return NULL;
-    	}
+        if (IntfIter == NULL)
+        {
+            return NULL;
+        }
 
-    	IntfIter->Index = 1;
+        IntfIter->Index = 1;
 
-    	Py_INCREF(obj);
-    	IntfIter->refobj = obj;
+        Py_INCREF(obj);
+        IntfIter->refobj = obj;
 
-    	result = (PyObject *)IntfIter;
-    	PyObject_GC_Track(result);
+        result = (PyObject *)IntfIter;
+        PyObject_GC_Track(result);
     }
     else
     {
-    	PyErr_Format(PyExc_RuntimeError, "Not an iterable interface");
+        PyErr_Format(PyExc_RuntimeError, "Not an iterable interface");
     }
     return result;
 }
@@ -435,7 +437,7 @@ static int CFE_MissionLib_Python_InterfaceIterator_clear(PyObject *obj)
 
 static PyObject *CFE_MissionLib_Python_InterfaceIterator_iternext(PyObject *obj)
 {
-	CFE_MissionLib_Python_InterfaceIterator_t *self = (CFE_MissionLib_Python_InterfaceIterator_t*)obj;
+    CFE_MissionLib_Python_InterfaceIterator_t *self = (CFE_MissionLib_Python_InterfaceIterator_t*)obj;
     CFE_MissionLib_Python_Interface_t *intf = NULL;
     const char * Label = NULL;
     uint16_t idx;
@@ -455,8 +457,8 @@ static PyObject *CFE_MissionLib_Python_InterfaceIterator_iternext(PyObject *obj)
 
         do
         {
-        	Label = CFE_MissionLib_GetTopicName(intf->DbObj->IntfDb, intf->InterfaceId, idx);
-        	++idx;
+            Label = CFE_MissionLib_GetTopicName(intf->DbObj->IntfDb, intf->InterfaceId, idx);
+            ++idx;
         }
         while((Label == NULL) && (idx <= intf->IntfInfo.NumTopics+1));
 
@@ -470,10 +472,8 @@ static PyObject *CFE_MissionLib_Python_InterfaceIterator_iternext(PyObject *obj)
             	Py_CLEAR(self->refobj);
             	break;
             }
-            Py_INCREF(key);
 
             topicid = PyLong_FromLong(idx-1);
-            Py_INCREF(topicid);
 
             self->Index = idx;
             result = PyTuple_Pack(2, key, topicid);

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_topic.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_topic.c
@@ -57,9 +57,9 @@ static PyObject *   CFE_MissionLib_Python_TopicIterator_iternext(PyObject *obj);
 
 struct CbArg
 {
-	uint8_t CommandCode;
-	EdsLib_Id_t PossibleId;
-	EdsLib_Id_t EdsId;
+    uint8_t CommandCode;
+    EdsLib_Id_t PossibleId;
+    EdsLib_Id_t EdsId;
 };
 
 typedef struct CbArg CbArg_t;
@@ -69,7 +69,7 @@ void SubcommandCallback(const EdsLib_DatabaseObject_t *GD, const EdsLib_DataType
 
 static PyMethodDef CFE_MissionLib_Python_Topic_methods[] =
 {
-		{"GetCmdEdsId", CFE_MissionLib_Python_Topic_GetCmdEdsIdFromCode, METH_VARARGS, "Get a CFE command message EDS Object from a Topic"},
+        {"GetCmdEdsId", CFE_MissionLib_Python_Topic_GetCmdEdsIdFromCode, METH_VARARGS, "Get a CFE command message EDS Object from a Topic"},
         {NULL}  /* Sentinel */
 };
 
@@ -94,10 +94,10 @@ PyTypeObject CFE_MissionLib_Python_TopicType =
     .tp_repr = CFE_MissionLib_Python_Topic_repr,
     .tp_traverse = CFE_MissionLib_Python_Topic_traverse,
     .tp_clear = CFE_MissionLib_Python_Topic_clear,
-	.tp_iter = CFE_MissionLib_Python_Topic_iter,
+    .tp_iter = CFE_MissionLib_Python_Topic_iter,
     .tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC,
     .tp_weaklistoffset = offsetof(CFE_MissionLib_Python_Topic_t, WeakRefList),
-    .tp_doc = "Topic entry"
+    .tp_doc = PyDoc_STR("Topic entry")
 };
 
 PyTypeObject CFE_MissionLib_Python_TopicIteratorType =
@@ -112,7 +112,7 @@ PyTypeObject CFE_MissionLib_Python_TopicIteratorType =
     .tp_clear = CFE_MissionLib_Python_TopicIterator_clear,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = CFE_MissionLib_Python_TopicIterator_iternext,
-	.tp_doc = PyDoc_STR("CFE MissionLib TopicIteratorType")
+    .tp_doc = PyDoc_STR("CFE MissionLib TopicIteratorType")
 };
 
 static int CFE_MissionLib_Python_Topic_traverse(PyObject *obj, visitproc visit, void *arg)
@@ -131,6 +131,7 @@ static int CFE_MissionLib_Python_Topic_clear(PyObject *obj)
     Py_CLEAR(self->IntfObj);
     Py_CLEAR(self->TopicName);
     Py_CLEAR(self->TypeCache);
+
     return 0;
 }
 
@@ -327,7 +328,7 @@ static PyObject *CFE_MissionLib_Python_Topic_new(PyTypeObject *obj, PyObject *ar
 
         if (IntfObj == NULL)
         {
-        	break;
+            break;
         }
 
         // Set up the topic with either a TopicId or Topic Name
@@ -429,7 +430,7 @@ PyObject *CFE_MissionLib_Python_Topic_GetFromTopicName(CFE_MissionLib_Python_Int
 static PyObject *  CFE_MissionLib_Python_Topic_iter(PyObject *obj)
 {
     CFE_MissionLib_Python_Topic_t *Topic = (CFE_MissionLib_Python_Topic_t *) obj;
-	CFE_MissionLib_Python_TopicIterator_t *TopicIter;
+    CFE_MissionLib_Python_TopicIterator_t *TopicIter;
     PyObject *result = NULL;
 
     if (Topic->IndInfo.NumSubcommands > 0)
@@ -438,7 +439,7 @@ static PyObject *  CFE_MissionLib_Python_Topic_iter(PyObject *obj)
 
     	if (TopicIter == NULL)
     	{
-    		return NULL;
+            return NULL;
     	}
 
     	Py_INCREF(obj);
@@ -467,6 +468,7 @@ static int CFE_MissionLib_Python_TopicIterator_traverse(PyObject *obj, visitproc
 {
     CFE_MissionLib_Python_TopicIterator_t *self = (CFE_MissionLib_Python_TopicIterator_t*)obj;
     Py_VISIT(self->refobj);
+
     return 0;
 }
 
@@ -474,12 +476,13 @@ static int CFE_MissionLib_Python_TopicIterator_clear(PyObject *obj)
 {
     CFE_MissionLib_Python_TopicIterator_t *self = (CFE_MissionLib_Python_TopicIterator_t*)obj;
     Py_CLEAR(self->refobj);
+
     return 0;
 }
 
 static PyObject *CFE_MissionLib_Python_TopicIterator_iternext(PyObject *obj)
 {
-	CFE_MissionLib_Python_TopicIterator_t *self = (CFE_MissionLib_Python_TopicIterator_t*)obj;
+    CFE_MissionLib_Python_TopicIterator_t *self = (CFE_MissionLib_Python_TopicIterator_t*)obj;
     CFE_MissionLib_Python_Topic_t *topic = NULL;
     EdsLib_Python_Database_t *EdsDb;
     uint16_t idx;
@@ -503,17 +506,14 @@ static PyObject *CFE_MissionLib_Python_TopicIterator_iternext(PyObject *obj)
         if (EdsLib_DataTypeDB_GetDerivedTypeById(EdsDb->GD, topic->EdsId, idx, &PossibleId) == EDSLIB_SUCCESS)
         {
 
-        	key = PyUnicode_FromString(EdsLib_DisplayDB_GetBaseName(EdsDb->GD, PossibleId));
-        	Py_INCREF(key);
+            key = PyUnicode_FromString(EdsLib_DisplayDB_GetBaseName(EdsDb->GD, PossibleId));
+            edsid = PyLong_FromLong((long int)PossibleId);
 
-        	edsid = PyLong_FromLong((long int)PossibleId);
-        	Py_INCREF(edsid);
-
-        	if((key == NULL) || (edsid == NULL))
-        	{
-        		Py_CLEAR(self->refobj);
-        		break;
-        	}
+            if ((key == NULL) || (edsid == NULL))
+            {
+                Py_CLEAR(self->refobj);
+                break;
+            }
 
             ++self->Index;
             result = PyTuple_Pack(2, key, edsid);
@@ -530,59 +530,56 @@ static PyObject *CFE_MissionLib_Python_TopicIterator_iternext(PyObject *obj)
 void SubcommandCallback(const EdsLib_DatabaseObject_t *GD, const EdsLib_DataTypeDB_EntityInfo_t *MemberInfo,
         EdsLib_GenericValueBuffer_t *ConstraintValue, void *Arg)
 {
-	CbArg_t *Argument = (CbArg_t *) Arg;
+    CbArg_t *Argument = (CbArg_t *) Arg;
 
-	if (ConstraintValue->Value.u8 == Argument->CommandCode )
-	{
-		Argument->EdsId = Argument->PossibleId;
-	}
+    if (ConstraintValue->Value.u8 == Argument->CommandCode )
+    {
+        Argument->EdsId = Argument->PossibleId;
+    }
 }
 
 static PyObject *CFE_MissionLib_Python_Topic_GetCmdEdsIdFromCode(PyObject *obj, PyObject *args)
 {
-	CFE_MissionLib_Python_Topic_t *self = (CFE_MissionLib_Python_Topic_t*) obj;
+    CFE_MissionLib_Python_Topic_t *self = (CFE_MissionLib_Python_Topic_t*) obj;
     EdsLib_Python_Database_t *EdsDb;
-	PyObject *arg1;
-	PyObject *tempargs;
-	uint8_t CommandCode;
-	int32_t idx;
+    PyObject *arg1;
+    uint8_t CommandCode;
+    int32_t idx;
     EdsLib_Id_t PossibleId;
     EdsLib_ConstraintCallback_t Callback = SubcommandCallback;
     CbArg_t Argument;
-    PyObject *result;
+    PyObject *result = NULL;
 
     do
     {
-		if (!PyArg_UnpackTuple(args, "CommandCode", 1, 1, &arg1))
-		{
-			PyErr_Format(PyExc_RuntimeError, "Topic arguments expected: Command Code");
-			return NULL;
-		}
+        if (!PyArg_UnpackTuple(args, "Command Code", 1, 1, &arg1))
+        {
+            break;
+        }
 
-		// Get the command code from the input argument
-		if (PyNumber_Check(arg1))
-		{
-			tempargs = PyNumber_Long(arg1);
-			if (tempargs == NULL)
-			{
-				break;
-			}
+        // Get the command code from the input argument
+        if (PyLong_Check(arg1))
+        {
+            CommandCode = PyLong_AsUnsignedLong(arg1);
+        }
+        else
+        {
+            PyErr_SetString(PyExc_TypeError, "Command Code argument: long expected");
+            break;
+        }
 
-			CommandCode = PyLong_AsUnsignedLong(tempargs);
-		}
+        EdsDb = self->IntfObj->DbObj->EdsDbObj;
+        Argument.CommandCode = CommandCode;
 
-		EdsDb = self->IntfObj->DbObj->EdsDbObj;
-		Argument.CommandCode = CommandCode;
+        for (idx = 0; idx < self->IndInfo.NumSubcommands; idx++)
+        {
+            EdsLib_DataTypeDB_GetDerivedTypeById(EdsDb->GD, self->EdsId, idx, &PossibleId);
+            Argument.PossibleId = PossibleId;
+            EdsLib_DataTypeDB_ConstraintIterator(EdsDb->GD, self->EdsId, PossibleId, Callback, (void *)&Argument);
+        }
 
-		for (idx = 0; idx < self->IndInfo.NumSubcommands; idx++)
-		{
-			EdsLib_DataTypeDB_GetDerivedTypeById(EdsDb->GD, self->EdsId, idx, &PossibleId);
-			Argument.PossibleId = PossibleId;
-			EdsLib_DataTypeDB_ConstraintIterator(EdsDb->GD, self->EdsId, PossibleId, Callback, (void *)&Argument);
-		}
+        result = PyLong_FromLong((long int) Argument.EdsId);
     } while(0);
 
-    Py_XDECREF(tempargs);
-    result = PyLong_FromLong((long int) Argument.EdsId);
     return result;
 }

--- a/edslib/fsw/src/edslib_datatypedb_errorcontrol.c
+++ b/edslib/fsw/src/edslib_datatypedb_errorcontrol.c
@@ -36,8 +36,24 @@
 #include <stdlib.h>
 #include "edslib_internal.h"
 
-
+/*
+ * CRC Algorithm: CRC-16/CCITT-FALSE
+ * Polynomial: 0x1021
+ * Initilization: 0xFFFF
+ * Input Reflection: False
+ * Output Reflection: False
+ * XOR Output: 0x0000
+ */
 #define EDSLIB_CRC16_CCITT_POLY     0x1021  /* x^16 + x^12 + x^5 + 1 */
+
+/*
+ * CRC Algorithm: CRC-8
+ * Polynomial: 0x07
+ * Initialization: 0x00
+ * Input Reflection: False
+ * Output Reflection: False
+ * XOR Output: 0x00
+ */
 #define EDSLIB_CRC8_POLY            0x07    /* x^8 + x^2 + x^1 + 1 */
 
 

--- a/edslib/python/src/edslib_python_databaseentry.c
+++ b/edslib/python/src/edslib_python_databaseentry.c
@@ -405,6 +405,7 @@ PyTypeObject *EdsLib_Python_DatabaseEntry_GetFromEdsId_Impl(EdsLib_Python_Databa
                 refdb->DbName,
                 EdsLib_DisplayDB_GetNamespace(refdb->GD, EdsId),
                 EdsLib_DisplayDB_GetBaseName(refdb->GD, EdsId));
+
         if (typename == NULL)
         {
             break;
@@ -488,6 +489,8 @@ static int EdsLib_Python_DatabaseEntry_traverse(PyObject *obj, visitproc visit, 
     Py_VISIT(self->EdsDb);
     Py_VISIT(self->BaseName);
     Py_VISIT(self->EdsTypeName);
+    Py_VISIT(self->SubEntityList);
+
     return EdsLib_Python_DatabaseEntryType.tp_base->tp_traverse(obj, visit, arg);
 }
 
@@ -497,6 +500,8 @@ static int EdsLib_Python_DatabaseEntry_clear(PyObject *obj)
     Py_CLEAR(self->EdsDb);
     Py_CLEAR(self->BaseName);
     Py_CLEAR(self->EdsTypeName);
+    Py_CLEAR(self->SubEntityList);
+
     return EdsLib_Python_DatabaseEntryType.tp_base->tp_clear(obj);
 }
 
@@ -605,14 +610,18 @@ static int EdsLib_Python_DatabaseEntry_init(PyObject *obj, PyObject *args, PyObj
 
     EdsLib_Python_DatabaseEntryType.tp_base->tp_init(obj, subargs, NULL);
 
+    Py_DECREF(subargs);
+
     return 0;
 }
 
 static void EdsLib_Python_DatabaseEntry_dealloc(PyObject * obj)
 {
     EdsLib_Python_DatabaseEntry_t *self = (EdsLib_Python_DatabaseEntry_t *)obj;
-
-    Py_CLEAR(self->EdsDb);
+    Py_XDECREF(self->EdsDb);
+    Py_XDECREF(self->BaseName);
+    Py_XDECREF(self->EdsTypeName);
+    Py_XDECREF(self->SubEntityList);
 
     /*
      * Call the base type dealloc in case there is complicated logic
@@ -673,6 +682,7 @@ static PyObject *EdsLib_Python_DatabaseEntry_seq_item(PyObject *obj, Py_ssize_t 
         {
             return NULL;
         }
+        Py_INCREF(attribute);
         result = PyObject_GetAttr(obj, attribute);
     }
     else if (idx < 0 || idx >= TypeInfo.NumSubElements)
@@ -739,7 +749,7 @@ Py_ssize_t EdsLib_Python_DatabaseEntry_GetMaxSize(PyTypeObject* objtype)
     return DerivInfo.MaxSize.Bytes;
 }
 
-static PyObject *  EdsLib_Python_DatabaseEntry_iter(PyObject *obj)
+static PyObject * EdsLib_Python_DatabaseEntry_iter(PyObject *obj)
 {
     EdsLib_Python_DatabaseEntry_t *dbent = (EdsLib_Python_DatabaseEntry_t *)obj;
     EdsLib_Python_EnumerationIterator_t *EnumIter;
@@ -848,8 +858,6 @@ static PyObject *EdsLib_Python_EnumEntryIterator_iternext(PyObject *obj)
             	break;
             }
 
-            Py_INCREF(key);
-            Py_INCREF(value);
             ++self->Index;
             result = PyTuple_Pack(2, key, value);
         }
@@ -889,7 +897,6 @@ static PyObject *EdsLib_Python_ContainerEntryIterator_iternext(PyObject *obj)
     EdsLib_Python_ContainerIterator_t *self = (EdsLib_Python_ContainerIterator_t*)obj;
     EdsLib_Python_DatabaseEntry_t *dbent = NULL;
 
-    PyObject *str;
     const char *keystr;
 
     EdsLib_DataTypeDB_EntityInfo_t CompInfo;
@@ -920,9 +927,7 @@ static PyObject *EdsLib_Python_ContainerEntryIterator_iternext(PyObject *obj)
             break;
         }
         Py_INCREF(key);
-
-        str = PyUnicode_AsEncodedString(key, "utf-8", "~E~");
-        keystr = PyBytes_AS_STRING(str);
+        keystr = (const char *)PyUnicode_DATA(key);
 
         if (EdsLib_DisplayDB_LocateSubEntity(dbent->EdsDb->GD, dbent->EdsId, keystr, &CompInfo) == EDSLIB_SUCCESS)
         {


### PR DESCRIPTION
This adds a few python binding modules for type checking of EDS objects in python (returns Py_True or Py_False)
    - IsArray, IsContainer, IsNumber, IsEnum

There are also a few minor cleanup items
    - Added CRC algorithm information in the edslib error control
    - Updated cfe_missionlib_api to get the number of topics in a given interface
    - Added a (likely unnecessary) Py_INCREF/Py_DECREF pair in an edslib python binding function.