### PR TITLE
Fix #8, only use "Buffer" type if derivatives extend containers

### DIFF
--- a/edslib/eds/40-seds_write_headers.lua
+++ b/edslib/eds/40-seds_write_headers.lua
@@ -72,7 +72,9 @@ local function write_c_struct_typedef(output,node)
       output:start_group("{")
       for idx,ref in ipairs(node.decode_sequence) do
         local c_name = ref.type:get_flattened_name()
-        if (ref.name and ref.type.max_size) then
+        -- If the entry refers to a base type, then use a buffer instead of a direct instance here,
+        -- but only if the derivatives actually do extend the type (i.e. add fields).
+        if (ref.name and ref.type.max_size and ref.type.max_size.bits > ref.type.resolved_size.bits) then
           c_name = c_name .. "_Buffer"
         end
         if (ref.entry) then

--- a/edslib/eds/45-seds_write_datatypedb_objects.lua
+++ b/edslib/eds/45-seds_write_datatypedb_objects.lua
@@ -497,7 +497,7 @@ local function write_c_derivative_descriptor(output,basename,node)
   local valuemap = {}
   local valuelist = {}
 
-  if (node.max_size) then
+  if (node.max_size and node.max_size.bits > node.resolved_size.bits) then
     maxbits = node.max_size.bits
     bufobj = "_Buffer_t"
   else


### PR DESCRIPTION
No need to use the "Buffer" type in a parent container that refers to a base type, when the derivatives do not actually add any additional entries to the container.

This corrects the structure and derivative list generator scripts to only check whether the max_size (size of largest derivative) is actually larger than that of the base type.