### PR TITLE
Additional updates to bring Caelum build up to par with Bootes

### DIFF
--- a/cfecfs/edsmsg/CMakeLists.txt
+++ b/cfecfs/edsmsg/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(${DEP} STATIC
 
     fsw/src/cfe_msg_sechdr_cmd.c
     fsw/src/cfe_msg_sechdr_tlm.c
+
+    fsw/src/cfe_msg_dispatcher.c
 )
 
 target_include_directories(${DEP} PUBLIC fsw/inc)

--- a/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
+++ b/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
@@ -83,12 +83,12 @@ union CFE_MSG_Message
     /**
      * EDS-defined base message structure
      */
-    CFE_HDR_Message_t    BaseMsg;
+    CFE_HDR_Message_t BaseMsg;
 
     /**
      * \brief Byte level access
      */
-    uint8                Byte[sizeof(CFE_HDR_Message_t)];
+    uint8 Byte[sizeof(CFE_HDR_Message_t)];
 };
 
 /**
@@ -129,6 +129,5 @@ static inline CFE_MSG_Message_t *CFE_MSG_CastBaseMsg(void *BaseMsg)
      */
     return ((CFE_MSG_Message_t *)BaseMsg);
 }
-
 
 #endif /* CFE_MSG_HDR_EDS_H */

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
@@ -29,10 +29,10 @@
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_missionlib_runtime.h"
 
-#define CFE_MSG_SHDR_PRESENT_MASK_BIT  (CCSDS_SecHdrFlags_Tlm & CCSDS_SecHdrFlags_Cmd)
-#define CFE_MSG_SHDR_TYPE_MASK_BIT     (CCSDS_SecHdrFlags_Tlm ^ CCSDS_SecHdrFlags_Cmd)
-#define CFE_MSG_SHDR_TYPE_TLM_BIT      (CCSDS_SecHdrFlags_BareTlm & CCSDS_SecHdrFlags_Tlm)
-#define CFE_MSG_SHDR_TYPE_CMD_BIT      (CCSDS_SecHdrFlags_BareCmd & CCSDS_SecHdrFlags_Cmd)
+#define CFE_MSG_SHDR_PRESENT_MASK_BIT (CCSDS_SecHdrFlags_Tlm & CCSDS_SecHdrFlags_Cmd)
+#define CFE_MSG_SHDR_TYPE_MASK_BIT    (CCSDS_SecHdrFlags_Tlm ^ CCSDS_SecHdrFlags_Cmd)
+#define CFE_MSG_SHDR_TYPE_TLM_BIT     (CCSDS_SecHdrFlags_BareTlm & CCSDS_SecHdrFlags_Tlm)
+#define CFE_MSG_SHDR_TYPE_CMD_BIT     (CCSDS_SecHdrFlags_BareCmd & CCSDS_SecHdrFlags_Cmd)
 
 #ifdef jphfix
 CFE_MSG_Message_t *CFE_MSG_ConvertPtr(CFE_MSG_BaseMsg_t *BaseMsg)
@@ -137,7 +137,7 @@ CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Ty
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    CCSDS_CommonHdr_t *      Hdr;
     CCSDS_SecHdrFlags_Enum_t SetVal;
 
     if (MsgPtr == NULL)
@@ -145,8 +145,8 @@ CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
-    SetVal  = 0;
+    Hdr    = (CCSDS_CommonHdr_t *)MsgPtr;
+    SetVal = 0;
 
     if (Type == CFE_MSG_Type_Tlm)
     {
@@ -201,7 +201,7 @@ CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    CCSDS_CommonHdr_t *      Hdr;
     CCSDS_SecHdrFlags_Enum_t SetVal;
 
     if (MsgPtr == NULL)

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_dispatcher.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_dispatcher.c
@@ -1,0 +1,159 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** Include Files
+*/
+#include <stdlib.h>
+#include <string.h>
+
+#include "edslib_datatypedb.h"
+#include "common_types.h"
+#include "cfe_error.h"
+#include "cfe_sb_api_typedefs.h"
+#include "cfe_msg.h"
+#include "cfe_config.h"
+
+#include "cfe_mission_eds_parameters.h"
+#include "cfe_mission_eds_interface_parameters.h"
+#include "cfe_missionlib_api.h"
+#include "cfe_missionlib_runtime.h"
+
+CFE_Status_t CFE_MSG_EdsDispatch(uint16 InterfaceID, uint16 IndicationIndex, uint16 DispatchTableID,
+                                 const CFE_SB_Buffer_t *Buffer, const void *DispatchTable)
+{
+    const EdsLib_DatabaseObject_t *       GD;
+    CFE_MissionLib_TopicInfo_t            TopicInfo;
+    CFE_MissionLib_IndicationInfo_t       IndicationInfo;
+    EdsLib_DataTypeDB_TypeInfo_t          TypeInfo;
+    CFE_SB_SoftwareBus_PubSub_Interface_t PubSubParams;
+    EdsLib_Id_t                           ArgumentType;
+    int32_t                               Status;
+    uint16_t                              TopicId;
+    uint16_t                              DispatchOffset;
+    CFE_MSG_Size_t                        BufferSize;
+    union
+    {
+        cpuaddr     MemAddr;
+        const void *GenericPtr;
+        int32 (**DispatchFunc)(const CFE_SB_Buffer_t *);
+    } HandlerPtr;
+
+    GD = CFE_Config_GetObjPointer(CFE_CONFIGID_MISSION_EDS_DB);
+
+    CFE_MSG_GetSize(&Buffer->Msg, &BufferSize);
+
+    HandlerPtr.GenericPtr = DispatchTable;
+    DispatchOffset        = 0;
+    CFE_MissionLib_Get_PubSub_Parameters(&PubSubParams, &Buffer->Msg.BaseMsg);
+
+    switch (InterfaceID)
+    {
+        case CFE_SB_Telemetry_Interface_ID:
+        {
+            CFE_SB_Publisher_Component_t PublisherParams;
+            CFE_MissionLib_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
+            TopicId = PublisherParams.Telemetry.TopicId;
+            break;
+        }
+        case CFE_SB_Telecommand_Interface_ID:
+        {
+            CFE_SB_Listener_Component_t ListenerParams;
+            CFE_MissionLib_UnmapListenerComponent(&ListenerParams, &PubSubParams);
+            TopicId = ListenerParams.Telecommand.TopicId;
+            break;
+        }
+        default:
+            TopicId = 0;
+            break;
+    }
+
+    Status = CFE_MissionLib_GetTopicInfo(&CFE_SOFTWAREBUS_INTERFACE, InterfaceID, TopicId, &TopicInfo);
+    if (Status != CFE_MISSIONLIB_SUCCESS)
+    {
+        return CFE_STATUS_UNKNOWN_MSG_ID;
+    }
+
+    if (TopicInfo.DispatchTableId != DispatchTableID)
+    {
+        return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
+    }
+
+    Status = CFE_MissionLib_GetIndicationInfo(&CFE_SOFTWAREBUS_INTERFACE, InterfaceID, TopicId, IndicationIndex,
+                                              &IndicationInfo);
+    if (Status != CFE_MISSIONLIB_SUCCESS || IndicationInfo.NumArguments != 1)
+    {
+        /*
+         * This dispatch function only handles single-argument commands defined in EDS.
+         * This is really a programmer/EDS error and not a runtime error if this occurs
+         */
+        return CFE_SB_NOT_IMPLEMENTED;
+    }
+
+    Status = CFE_MissionLib_GetArgumentType(&CFE_SOFTWAREBUS_INTERFACE, InterfaceID, TopicId, IndicationIndex, 1,
+                                            &ArgumentType);
+    if (Status != CFE_MISSIONLIB_SUCCESS)
+    {
+        return CFE_SB_INTERNAL_ERR;
+    }
+
+    if (IndicationInfo.SubcommandArgumentId == 1 && IndicationInfo.NumSubcommands > 0)
+    {
+        /* Derived command case -- the indication corresponds to a multiple entries in the dispatch table.
+         * The actual type of the argument must be determined to figure out which one to invoke. */
+        EdsLib_DataTypeDB_DerivativeObjectInfo_t DerivObjInfo;
+
+        Status = EdsLib_DataTypeDB_IdentifyBuffer(GD, ArgumentType, Buffer->Msg.Byte, &DerivObjInfo);
+        if (Status != EDSLIB_SUCCESS)
+        {
+            return CFE_STATUS_UNKNOWN_MSG_ID;
+        }
+
+        /* NOTE: The "IdentifyBuffer" outputs a 0-based index, but the Subcommand is a 1-based index */
+        Status = CFE_MissionLib_GetSubcommandOffset(&CFE_SOFTWAREBUS_INTERFACE, InterfaceID, TopicId, IndicationIndex,
+                                                    1 + DerivObjInfo.DerivativeTableIndex, &DispatchOffset);
+        if (Status != EDSLIB_SUCCESS)
+        {
+            return CFE_STATUS_BAD_COMMAND_CODE;
+        }
+
+        ArgumentType = DerivObjInfo.EdsId;
+    }
+
+    Status = EdsLib_DataTypeDB_GetTypeInfo(GD, ArgumentType, &TypeInfo);
+    if (Status != EDSLIB_SUCCESS)
+    {
+        return CFE_SB_INTERNAL_ERR;
+    }
+
+    if (TypeInfo.Size.Bytes > BufferSize)
+    {
+        return CFE_STATUS_WRONG_MSG_LENGTH;
+    }
+
+    HandlerPtr.MemAddr += TopicInfo.DispatchStartOffset;
+    HandlerPtr.MemAddr += DispatchOffset;
+    if (*HandlerPtr.DispatchFunc == NULL)
+    {
+        return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
+    }
+
+    return (*HandlerPtr.DispatchFunc)(Buffer);
+}

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_init.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_init.c
@@ -27,7 +27,6 @@
 #include "cfe_msg.h"
 #include "cfe_missionlib_runtime.h"
 
-
 /*----------------------------------------------------------------
  *
  * Function: CFE_MSG_Init
@@ -39,7 +38,7 @@
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
     CCSDS_CommonHdr_t *CommonHdr;
-    CFE_Status_t Status;
+    CFE_Status_t       Status;
 
     if (MsgPtr == NULL || Size < sizeof(CCSDS_CommonHdr_t))
     {

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
@@ -41,7 +41,7 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 {
-    CFE_Status_t          Status;
+    CFE_Status_t                          Status;
     CFE_SB_SoftwareBus_PubSub_Interface_t Params;
 
     if (Type == NULL)
@@ -53,17 +53,17 @@ CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type
         Params.MsgId = MsgId;
         if (CFE_MissionLib_PubSub_IsListenerComponent(&Params))
         {
-            *Type = CFE_MSG_Type_Cmd;
+            *Type  = CFE_MSG_Type_Cmd;
             Status = CFE_SUCCESS;
         }
         else if (CFE_MissionLib_PubSub_IsPublisherComponent(&Params))
         {
-            *Type = CFE_MSG_Type_Tlm;
+            *Type  = CFE_MSG_Type_Tlm;
             Status = CFE_SUCCESS;
         }
         else
         {
-            *Type = CFE_MSG_Type_Invalid;
+            *Type  = CFE_MSG_Type_Invalid;
             Status = CFE_MSG_BAD_ARGUMENT;
         }
     }

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_cmd.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_cmd.c
@@ -34,7 +34,7 @@
 CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode)
 {
     const CFE_HDR_CommandHeader_t *CmdPtr;
-    const CCSDS_CommonHdr_t *CommonHdr;
+    const CCSDS_CommonHdr_t *      CommonHdr;
 
     if (MsgPtr == NULL || FcnCode == NULL)
     {

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_tlm.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_tlm.c
@@ -32,7 +32,7 @@
 CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
 {
     CFE_HDR_TelemetryHeader_t *TlmPtr;
-    const CCSDS_CommonHdr_t *CommonHdr;
+    const CCSDS_CommonHdr_t *  CommonHdr;
 
     if (MsgPtr == NULL)
     {
@@ -75,7 +75,7 @@ CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Ne
 CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time)
 {
     const CFE_HDR_TelemetryHeader_t *TlmPtr;
-    const CCSDS_CommonHdr_t *CommonHdr;
+    const CCSDS_CommonHdr_t *        CommonHdr;
 
     if (MsgPtr == NULL || Time == NULL)
     {

--- a/cfecfs/missionlib/eds/75-cfe_sb_dispatch_tables.lua
+++ b/cfecfs/missionlib/eds/75-cfe_sb_dispatch_tables.lua
@@ -272,7 +272,7 @@ for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
   end
 
   hdrout = SEDS.output_open(SEDS.to_filename("dispatcher.h", ds.name), ds.xml_filename)
-  hdrout:write(string.format("#include \"cfe_sb_eds.h\""))
+  hdrout:write(string.format("#include \"cfe_msg_dispatcher.h\""))
   hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("interfacedb.h", global_sym_prefix)))
   hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("interface.h", ds.name)))
   hdrout:add_whitespace(1)
@@ -282,11 +282,11 @@ for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
     local entry = total_intfs[i]
     hdrout:start_group(string.format("static inline int32_t %s_Dispatch(",entry.output_name))
     hdrout:write(string.format("%-65s IndicationId,", entry.intf:get_flattened_name() .. "_IndicationId_t"))
-    hdrout:write(string.format("%-65s *Message,", "const CFE_SB_Msg_t"))
+    hdrout:write(string.format("%-65s *Message,", "const CFE_SB_Buffer_t"))
     hdrout:write(string.format("%-65s *DispatchTable","const " .. entry.output_name .. "_DispatchTable_t"))
     hdrout:end_group(")")
     hdrout:start_group("{")
-    hdrout:start_group("return CFE_SB_EDS_Dispatch(")
+    hdrout:start_group("return CFE_MSG_EdsDispatch(")
     hdrout:write(string.format("%s,", entry.intf:get_flattened_name() .. "_ID"))
     hdrout:write(string.format("IndicationId - %s,", entry.intf:get_flattened_name() .. "_INDICATION_BASE"))
     hdrout:write(string.format("%s_DISPATCHTABLE_ID,",entry.output_name))

--- a/cfecfs/missionlib/fsw/inc/cfe_missionlib_api.h
+++ b/cfecfs/missionlib/fsw/inc/cfe_missionlib_api.h
@@ -1,23 +1,22 @@
 /*
  * LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
- * 
+ *
  * Copyright (c) 2020 United States Government as represented by
  * the Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 /**
  * \file     cfe_missionlib_api.h
@@ -30,7 +29,6 @@
 
 #ifndef _CFE_MISSIONLIB_API_H_
 #define _CFE_MISSIONLIB_API_H_
-
 
 /*
  * The EDS library uses the fixed-width types from the C99 stdint.h header file,
@@ -46,23 +44,21 @@
  * MACROS
  ******************************/
 
-
-
 /******************************
  * TYPEDEFS
  ******************************/
 
 enum
 {
-    CFE_MISSIONLIB_NOT_IMPLEMENTED = -10,
+    CFE_MISSIONLIB_NOT_IMPLEMENTED    = -10,
     CFE_MISSIONLIB_INVALID_SUBCOMMAND = -6,
-    CFE_MISSIONLIB_INVALID_ARGUMENT = -6,
+    CFE_MISSIONLIB_INVALID_ARGUMENT   = -6,
     CFE_MISSIONLIB_INVALID_INDICATION = -5,
-    CFE_MISSIONLIB_INVALID_TOPIC = -4,
-    CFE_MISSIONLIB_INVALID_MESSAGE = -3,
-    CFE_MISSIONLIB_INVALID_INTERFACE = -2,
-    CFE_MISSIONLIB_FAILURE = -1,
-    CFE_MISSIONLIB_SUCCESS = 0
+    CFE_MISSIONLIB_INVALID_TOPIC      = -4,
+    CFE_MISSIONLIB_INVALID_MESSAGE    = -3,
+    CFE_MISSIONLIB_INVALID_INTERFACE  = -2,
+    CFE_MISSIONLIB_FAILURE            = -1,
+    CFE_MISSIONLIB_SUCCESS            = 0
 };
 
 typedef struct CFE_MissionLib_SoftwareBus_Interface CFE_MissionLib_SoftwareBus_Interface_t;
@@ -107,27 +103,41 @@ extern "C"
 {
 #endif
 
-const char *CFE_MissionLib_GetInstanceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InstanceNum, char *Buffer, uint32_t BufferSize);
-uint16_t CFE_MissionLib_GetInstanceNumber(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *String);
+    const char *CFE_MissionLib_GetInstanceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InstanceNum,
+                                               char *Buffer, uint32_t BufferSize);
+    uint16_t CFE_MissionLib_GetInstanceNumber(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *String);
 
-int32_t CFE_MissionLib_GetIndicationInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, CFE_MissionLib_IndicationInfo_t *IndInfo);
-int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, CFE_MissionLib_InterfaceInfo_t *IntfInfo);
-int32_t CFE_MissionLib_GetTopicInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, CFE_MissionLib_TopicInfo_t *TopicInfo);
-int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, uint16_t ArgumentId, EdsLib_Id_t *Id);
-int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, uint16_t SubcommandId, uint16_t *Offset);
+    int32_t CFE_MissionLib_GetIndicationInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                             uint16_t TopicId, uint16_t IndicationId,
+                                             CFE_MissionLib_IndicationInfo_t *IndInfo);
+    int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                            CFE_MissionLib_InterfaceInfo_t *IntfInfo);
+    int32_t CFE_MissionLib_GetTopicInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                        uint16_t TopicId, CFE_MissionLib_TopicInfo_t *TopicInfo);
+    int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                           uint16_t TopicId, uint16_t IndicationId, uint16_t ArgumentId,
+                                           EdsLib_Id_t *Id);
+    int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Interface_t *Intf,
+                                               uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId,
+                                               uint16_t SubcommandId, uint16_t *Offset);
 
-int32_t CFE_MissionLib_FindInterfaceByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *IntfName, uint16_t *InterfaceIdBuffer);
-int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, const char *TopicName, uint16_t *TopicIdBuffer);
-int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, const char *CommandName, uint16_t *CommandIdBuffer);
-const char *CFE_MissionLib_GetTopicName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId);
-const char *CFE_MissionLib_GetInterfaceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType);
-const char *CFE_MissionLib_GetCommandName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t CommandId);
-void CFE_MissionLib_EnumerateTopics(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, CFE_MissionLib_TopicInfo_Callback_t Callback, void *OpaqueArg);
+    int32_t CFE_MissionLib_FindInterfaceByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *IntfName,
+                                               uint16_t *InterfaceIdBuffer);
+    int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                           const char *TopicName, uint16_t *TopicIdBuffer);
+    int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                             const char *CommandName, uint16_t *CommandIdBuffer);
+    const char *CFE_MissionLib_GetTopicName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                            uint16_t TopicId);
+    const char *CFE_MissionLib_GetInterfaceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf,
+                                                uint16_t                                      InterfaceType);
+    const char *CFE_MissionLib_GetCommandName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf,
+                                              uint16_t InterfaceType, uint16_t CommandId);
+    void CFE_MissionLib_EnumerateTopics(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                        CFE_MissionLib_TopicInfo_Callback_t Callback, void *OpaqueArg);
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-
-#endif  /* _CFE_MISSIONLIB_API_H_ */
-
+#endif /* _CFE_MISSIONLIB_API_H_ */

--- a/cfecfs/missionlib/fsw/inc/cfe_missionlib_runtime.h
+++ b/cfecfs/missionlib/fsw/inc/cfe_missionlib_runtime.h
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 /**
  * \file     cfe_missionlib_runtime.h
  * \ingroup  fsw
@@ -52,7 +51,7 @@
 #define CFE_MISSIONLIB_SpacePacketBasic_HEADERS 1
 #define CFE_MISSIONLIB_SpacePacketApidQ_HEADERS 2
 
-#define CFE_MISSIONLIB_CFGSYM_TO_HDRTYPE(hdr) CFE_MISSIONLIB_ ## hdr ## _HEADERS
+#define CFE_MISSIONLIB_CFGSYM_TO_HDRTYPE(hdr) CFE_MISSIONLIB_##hdr##_HEADERS
 #define CFE_MISSIONLIB_HDRTYPE(sym)           CFE_MISSIONLIB_CFGSYM_TO_HDRTYPE(sym)
 
 /*
@@ -63,28 +62,32 @@
  *
  * When used in a numeric context, it resolves to the CCSDS version field +1.
  */
-#define CFE_MISSIONLIB_SELECTED_HDRTYPE       CFE_MISSIONLIB_HDRTYPE(CFE_MISSION_MSG_HEADER_TYPE)
+#define CFE_MISSIONLIB_SELECTED_HDRTYPE CFE_MISSIONLIB_HDRTYPE(CFE_MISSION_MSG_HEADER_TYPE)
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+    void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
+                                             const CFE_SB_Listener_Component_t *    Input);
+    void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *                Output,
+                                               const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
+    void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
+                                              const CFE_SB_Publisher_Component_t *   Input);
+    void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *               Output,
+                                                const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
 
-void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output, const CFE_SB_Listener_Component_t *Input);
-void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *Output, const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
-void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output, const CFE_SB_Publisher_Component_t *Input);
-void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *Output, const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
+    bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
+    bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
 
-bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
-bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
-
-void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params, const CFE_HDR_Message_t *Packet);
-void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *Packet, const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
+    void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params,
+                                              const CFE_HDR_Message_t *              Packet);
+    void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                          Packet,
+                                              const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-
-#endif  /* _CFE_MISSIONLIB_RUNTIME_H_ */
+#endif /* _CFE_MISSIONLIB_RUNTIME_H_ */

--- a/cfecfs/missionlib/fsw/src/cfe_missionlib_api.c
+++ b/cfecfs/missionlib/fsw/src/cfe_missionlib_api.c
@@ -1,23 +1,22 @@
 /*
  * LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
- * 
+ *
  * Copyright (c) 2020 United States Government as represented by
  * the Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 /**
  * \file     cfe_missionlib_api.c
@@ -55,7 +54,8 @@
  * ***********************************************************************
  */
 
-static const CFE_MissionLib_InterfaceId_Entry_t *CFE_MissionLib_Lookup_SubIntf(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType)
+static const CFE_MissionLib_InterfaceId_Entry_t *
+CFE_MissionLib_Lookup_SubIntf(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType)
 {
     if (InterfaceType == 0 || InterfaceType > Intf->NumInterfaces)
     {
@@ -65,7 +65,8 @@ static const CFE_MissionLib_InterfaceId_Entry_t *CFE_MissionLib_Lookup_SubIntf(c
     return &Intf->InterfaceList[InterfaceType - 1];
 }
 
-static const CFE_MissionLib_TopicId_Entry_t *CFE_MissionLib_Lookup_Topic(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr, uint16_t TopicId)
+static const CFE_MissionLib_TopicId_Entry_t *
+CFE_MissionLib_Lookup_Topic(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr, uint16_t TopicId)
 {
     if (IntfPtr == NULL || TopicId == 0 || TopicId > IntfPtr->NumTopics)
     {
@@ -75,7 +76,8 @@ static const CFE_MissionLib_TopicId_Entry_t *CFE_MissionLib_Lookup_Topic(const C
     return &IntfPtr->TopicList[TopicId - 1];
 }
 
-static const CFE_MissionLib_Command_Prototype_Entry_t *CFE_MissionLib_Lookup_Command_Prototype(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr, uint16_t IndicationId)
+static const CFE_MissionLib_Command_Prototype_Entry_t *
+CFE_MissionLib_Lookup_Command_Prototype(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr, uint16_t IndicationId)
 {
     if (IntfPtr == NULL || IndicationId == 0 || IndicationId > IntfPtr->NumCommands)
     {
@@ -85,7 +87,9 @@ static const CFE_MissionLib_Command_Prototype_Entry_t *CFE_MissionLib_Lookup_Com
     return &IntfPtr->CommandList[IndicationId - 1];
 }
 
-static const CFE_MissionLib_Command_Definition_Entry_t *CFE_MissionLib_Lookup_Command_Definition(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr, const CFE_MissionLib_TopicId_Entry_t *TopicPtr, uint16_t IndicationId)
+static const CFE_MissionLib_Command_Definition_Entry_t *
+CFE_MissionLib_Lookup_Command_Definition(const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr,
+                                         const CFE_MissionLib_TopicId_Entry_t *TopicPtr, uint16_t IndicationId)
 {
     if (IntfPtr == NULL || TopicPtr == NULL || IndicationId == 0 || IndicationId > IntfPtr->NumCommands)
     {
@@ -95,7 +99,10 @@ static const CFE_MissionLib_Command_Definition_Entry_t *CFE_MissionLib_Lookup_Co
     return &TopicPtr->CommandList[IndicationId - 1];
 }
 
-static const CFE_MissionLib_Argument_Entry_t *CFE_MissionLib_Lookup_Command_Argument(const CFE_MissionLib_Command_Definition_Entry_t *CmdPtr, const CFE_MissionLib_Command_Prototype_Entry_t *PrototypePtr, uint16_t ArgumentId)
+static const CFE_MissionLib_Argument_Entry_t *
+CFE_MissionLib_Lookup_Command_Argument(const CFE_MissionLib_Command_Definition_Entry_t *CmdPtr,
+                                       const CFE_MissionLib_Command_Prototype_Entry_t * PrototypePtr,
+                                       uint16_t                                         ArgumentId)
 {
     if (CmdPtr == NULL || PrototypePtr == NULL || ArgumentId == 0 || ArgumentId > PrototypePtr->NumArguments)
     {
@@ -105,7 +112,8 @@ static const CFE_MissionLib_Argument_Entry_t *CFE_MissionLib_Lookup_Command_Argu
     return &CmdPtr->ArgumentList[ArgumentId - 1];
 }
 
-static const CFE_MissionLib_Subcommand_Entry_t *CFE_MissionLib_Lookup_Subcommand(const CFE_MissionLib_Command_Definition_Entry_t *CmdPtr, uint16_t SubcommandId)
+static const CFE_MissionLib_Subcommand_Entry_t *
+CFE_MissionLib_Lookup_Subcommand(const CFE_MissionLib_Command_Definition_Entry_t *CmdPtr, uint16_t SubcommandId)
 {
     if (CmdPtr == NULL || SubcommandId == 0 || SubcommandId > CmdPtr->SubcommandCount)
     {
@@ -115,17 +123,17 @@ static const CFE_MissionLib_Subcommand_Entry_t *CFE_MissionLib_Lookup_Subcommand
     return &CmdPtr->SubcommandList[SubcommandId - 1];
 }
 
-
 /*
  * ***********************************************************************
  *  PUBLIC API FUNCTIONS (non-static)
  * ***********************************************************************
  */
 
-int32_t CFE_MissionLib_GetTopicInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, CFE_MissionLib_TopicInfo_t *TopicInfo)
+int32_t CFE_MissionLib_GetTopicInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                    uint16_t TopicId, CFE_MissionLib_TopicInfo_t *TopicInfo)
 {
     const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
+    const CFE_MissionLib_TopicId_Entry_t *    TopicPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -144,17 +152,19 @@ int32_t CFE_MissionLib_GetTopicInfo(const CFE_MissionLib_SoftwareBus_Interface_t
         return CFE_MISSIONLIB_INVALID_INTERFACE;
     }
 
-    TopicInfo->DispatchTableId = TopicPtr->DispatchTableId;
+    TopicInfo->DispatchTableId     = TopicPtr->DispatchTableId;
     TopicInfo->DispatchStartOffset = TopicPtr->DispatchStartOffset;
 
     return CFE_MISSIONLIB_SUCCESS;
 }
 
-int32_t CFE_MissionLib_GetIndicationInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, CFE_MissionLib_IndicationInfo_t *IndInfo)
+int32_t CFE_MissionLib_GetIndicationInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                         uint16_t TopicId, uint16_t IndicationId,
+                                         CFE_MissionLib_IndicationInfo_t *IndInfo)
 {
-    const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
-    const CFE_MissionLib_Command_Prototype_Entry_t *CmdProtoPtr;
+    const CFE_MissionLib_InterfaceId_Entry_t *       IntfPtr;
+    const CFE_MissionLib_TopicId_Entry_t *           TopicPtr;
+    const CFE_MissionLib_Command_Prototype_Entry_t * CmdProtoPtr;
     const CFE_MissionLib_Command_Definition_Entry_t *CmdDefPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
@@ -175,27 +185,28 @@ int32_t CFE_MissionLib_GetIndicationInfo(const CFE_MissionLib_SoftwareBus_Interf
     }
 
     CmdProtoPtr = CFE_MissionLib_Lookup_Command_Prototype(IntfPtr, IndicationId);
-    CmdDefPtr = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
+    CmdDefPtr   = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
     if (CmdProtoPtr == NULL || CmdDefPtr == NULL)
     {
         return CFE_MISSIONLIB_INVALID_INDICATION;
     }
 
     memset(IndInfo, 0, sizeof(*IndInfo));
-    IndInfo->NumArguments = CmdProtoPtr->NumArguments;
-    IndInfo->NumSubcommands = CmdDefPtr->SubcommandCount;
+    IndInfo->NumArguments         = CmdProtoPtr->NumArguments;
+    IndInfo->NumSubcommands       = CmdDefPtr->SubcommandCount;
     IndInfo->SubcommandArgumentId = CmdDefPtr->SubcommandArg;
 
     return CFE_MISSIONLIB_SUCCESS;
 }
 
-int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, uint16_t ArgumentId, EdsLib_Id_t *Id)
+int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                       uint16_t TopicId, uint16_t IndicationId, uint16_t ArgumentId, EdsLib_Id_t *Id)
 {
-    const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
-    const CFE_MissionLib_Command_Prototype_Entry_t *CmdProtoPtr;
+    const CFE_MissionLib_InterfaceId_Entry_t *       IntfPtr;
+    const CFE_MissionLib_TopicId_Entry_t *           TopicPtr;
+    const CFE_MissionLib_Command_Prototype_Entry_t * CmdProtoPtr;
     const CFE_MissionLib_Command_Definition_Entry_t *CmdDefPtr;
-    const CFE_MissionLib_Argument_Entry_t *ArgPtr;
+    const CFE_MissionLib_Argument_Entry_t *          ArgPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -215,7 +226,7 @@ int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interfac
     }
 
     CmdProtoPtr = CFE_MissionLib_Lookup_Command_Prototype(IntfPtr, IndicationId);
-    CmdDefPtr = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
+    CmdDefPtr   = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
     if (CmdProtoPtr == NULL || CmdDefPtr == NULL)
     {
         return CFE_MISSIONLIB_INVALID_INDICATION;
@@ -227,12 +238,13 @@ int32_t CFE_MissionLib_GetArgumentType(const CFE_MissionLib_SoftwareBus_Interfac
         return CFE_MISSIONLIB_INVALID_ARGUMENT;
     }
 
-    *Id = EDSLIB_MAKE_ID(ArgPtr->AppIndex,ArgPtr->TypeIndex);
+    *Id = EDSLIB_MAKE_ID(ArgPtr->AppIndex, ArgPtr->TypeIndex);
 
     return CFE_MISSIONLIB_SUCCESS;
 }
 
-int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceId, CFE_MissionLib_InterfaceInfo_t *IntfInfo)
+int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceId,
+                                        CFE_MissionLib_InterfaceInfo_t *IntfInfo)
 {
     int32_t Status;
 
@@ -242,21 +254,23 @@ int32_t CFE_MissionLib_GetInterfaceInfo(const CFE_MissionLib_SoftwareBus_Interfa
     }
     else
     {
-        Status = CFE_MISSIONLIB_SUCCESS;
-        IntfInfo->NumCommands = Intf->InterfaceList[InterfaceId-1].NumCommands;
-        IntfInfo->NumTopics = Intf->InterfaceList[InterfaceId-1].NumTopics;
+        Status                = CFE_MISSIONLIB_SUCCESS;
+        IntfInfo->NumCommands = Intf->InterfaceList[InterfaceId - 1].NumCommands;
+        IntfInfo->NumTopics   = Intf->InterfaceList[InterfaceId - 1].NumTopics;
     }
 
     return Status;
 }
 
-int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId, uint16_t IndicationId, uint16_t SubcommandId, uint16_t *Offset)
+int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                           uint16_t TopicId, uint16_t IndicationId, uint16_t SubcommandId,
+                                           uint16_t *Offset)
 {
-    const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
-    const CFE_MissionLib_Command_Prototype_Entry_t *CmdProtoPtr;
+    const CFE_MissionLib_InterfaceId_Entry_t *       IntfPtr;
+    const CFE_MissionLib_TopicId_Entry_t *           TopicPtr;
+    const CFE_MissionLib_Command_Prototype_Entry_t * CmdProtoPtr;
     const CFE_MissionLib_Command_Definition_Entry_t *CmdDefPtr;
-    const CFE_MissionLib_Subcommand_Entry_t *SubCmdPtr;
+    const CFE_MissionLib_Subcommand_Entry_t *        SubCmdPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -276,7 +290,7 @@ int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Inte
     }
 
     CmdProtoPtr = CFE_MissionLib_Lookup_Command_Prototype(IntfPtr, IndicationId);
-    CmdDefPtr = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
+    CmdDefPtr   = CFE_MissionLib_Lookup_Command_Definition(IntfPtr, TopicPtr, IndicationId);
     if (CmdProtoPtr == NULL || CmdDefPtr == NULL)
     {
         return CFE_MISSIONLIB_INVALID_INDICATION;
@@ -293,16 +307,17 @@ int32_t CFE_MissionLib_GetSubcommandOffset(const CFE_MissionLib_SoftwareBus_Inte
     return CFE_MISSIONLIB_SUCCESS;
 }
 
-int32_t CFE_MissionLib_FindInterfaceByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *IntfName, uint16_t *InterfaceIdBuffer)
+int32_t CFE_MissionLib_FindInterfaceByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *IntfName,
+                                           uint16_t *InterfaceIdBuffer)
 {
     uint16_t InterfaceId;
-    int32_t Status = CFE_MISSIONLIB_INVALID_INTERFACE;
+    int32_t  Status = CFE_MISSIONLIB_INVALID_INTERFACE;
 
     for (InterfaceId = 0; InterfaceId < Intf->NumInterfaces; ++InterfaceId)
     {
         if (strcmp(Intf->InterfaceList[InterfaceId].InterfaceName, IntfName) == 0)
         {
-            Status = CFE_MISSIONLIB_SUCCESS;
+            Status             = CFE_MISSIONLIB_SUCCESS;
             *InterfaceIdBuffer = 1 + InterfaceId;
             break;
         }
@@ -311,12 +326,13 @@ int32_t CFE_MissionLib_FindInterfaceByName(const CFE_MissionLib_SoftwareBus_Inte
     return Status;
 }
 
-int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, const char *TopicName, uint16_t *TopicIdBuffer)
+int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                       const char *TopicName, uint16_t *TopicIdBuffer)
 {
     const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
-    uint16_t TopicId;
-    int32_t Status;
+    const CFE_MissionLib_TopicId_Entry_t *    TopicPtr;
+    uint16_t                                  TopicId;
+    int32_t                                   Status;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -329,11 +345,10 @@ int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interfac
         for (TopicId = 0; TopicId < IntfPtr->NumTopics; ++TopicId)
         {
             TopicPtr = &IntfPtr->TopicList[TopicId];
-            if (TopicPtr->InterfaceId == InterfaceType &&
-                    TopicPtr->TopicName != NULL &&
-                    strcmp(TopicPtr->TopicName, TopicName) == 0)
+            if (TopicPtr->InterfaceId == InterfaceType && TopicPtr->TopicName != NULL &&
+                strcmp(TopicPtr->TopicName, TopicName) == 0)
             {
-                Status = CFE_MISSIONLIB_SUCCESS;
+                Status         = CFE_MISSIONLIB_SUCCESS;
                 *TopicIdBuffer = 1 + TopicId;
                 break;
             }
@@ -343,12 +358,13 @@ int32_t CFE_MissionLib_FindTopicByName(const CFE_MissionLib_SoftwareBus_Interfac
     return Status;
 }
 
-int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, const char *CommandName, uint16_t *CommandIdBuffer)
+int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                         const char *CommandName, uint16_t *CommandIdBuffer)
 {
-    const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
+    const CFE_MissionLib_InterfaceId_Entry_t *      IntfPtr;
     const CFE_MissionLib_Command_Prototype_Entry_t *CmdPtr;
-    uint16_t CommandId;
-    int32_t Status;
+    uint16_t                                        CommandId;
+    int32_t                                         Status;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -363,7 +379,7 @@ int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interf
             CmdPtr = &IntfPtr->CommandList[CommandId];
             if (CmdPtr->CommandName != NULL && strcmp(CmdPtr->CommandName, CommandName) == 0)
             {
-                Status = CFE_MISSIONLIB_SUCCESS;
+                Status           = CFE_MISSIONLIB_SUCCESS;
                 *CommandIdBuffer = 1 + CommandId;
                 break;
             }
@@ -373,9 +389,10 @@ int32_t CFE_MissionLib_FindCommandByName(const CFE_MissionLib_SoftwareBus_Interf
     return Status;
 }
 
-const char *CFE_MissionLib_GetCommandName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t CommandId)
+const char *CFE_MissionLib_GetCommandName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                          uint16_t CommandId)
 {
-    const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
+    const CFE_MissionLib_InterfaceId_Entry_t *      IntfPtr;
     const CFE_MissionLib_Command_Prototype_Entry_t *CmdProtoPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
@@ -393,10 +410,11 @@ const char *CFE_MissionLib_GetCommandName(const CFE_MissionLib_SoftwareBus_Inter
     return CmdProtoPtr->CommandName;
 }
 
-const char *CFE_MissionLib_GetTopicName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, uint16_t TopicId)
+const char *CFE_MissionLib_GetTopicName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                        uint16_t TopicId)
 {
     const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
+    const CFE_MissionLib_TopicId_Entry_t *    TopicPtr;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr == NULL)
@@ -426,15 +444,16 @@ const char *CFE_MissionLib_GetInterfaceName(const CFE_MissionLib_SoftwareBus_Int
     return IntfPtr->InterfaceName;
 }
 
-const char *CFE_MissionLib_GetInstanceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InstanceNum, char *Buffer, uint32_t BufferSize)
+const char *CFE_MissionLib_GetInstanceName(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InstanceNum,
+                                           char *Buffer, uint32_t BufferSize)
 {
-    uint16_t NameNum;
-    const char * const *InstanceName;
-    const char *Result;
+    uint16_t           NameNum;
+    const char *const *InstanceName;
+    const char *       Result;
 
     if (InstanceNum > 0 && Intf->InstanceList != NULL)
     {
-        NameNum = InstanceNum - 1;
+        NameNum      = InstanceNum - 1;
         InstanceName = Intf->InstanceList;
         while (*InstanceName != NULL && NameNum > 0)
         {
@@ -473,17 +492,17 @@ const char *CFE_MissionLib_GetInstanceName(const CFE_MissionLib_SoftwareBus_Inte
 
 uint16_t CFE_MissionLib_GetInstanceNumber(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, const char *String)
 {
-    uint16_t InstanceNum;
-    size_t PartLength;
+    uint16_t    InstanceNum;
+    size_t      PartLength;
     const char *EndPtr;
 
     PartLength = strlen(String);
     if (Intf->InstanceList != NULL)
     {
-        for(InstanceNum = 0; Intf->InstanceList[InstanceNum] != NULL; ++InstanceNum)
+        for (InstanceNum = 0; Intf->InstanceList[InstanceNum] != NULL; ++InstanceNum)
         {
             if (strncmp(Intf->InstanceList[InstanceNum], String, PartLength) == 0 &&
-                    Intf->InstanceList[InstanceNum][PartLength] == 0)
+                Intf->InstanceList[InstanceNum][PartLength] == 0)
             {
                 break;
             }
@@ -507,11 +526,12 @@ uint16_t CFE_MissionLib_GetInstanceNumber(const CFE_MissionLib_SoftwareBus_Inter
     return InstanceNum;
 }
 
-void CFE_MissionLib_EnumerateTopics(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType, CFE_MissionLib_TopicInfo_Callback_t Callback, void *OpaqueArg)
+void CFE_MissionLib_EnumerateTopics(const CFE_MissionLib_SoftwareBus_Interface_t *Intf, uint16_t InterfaceType,
+                                    CFE_MissionLib_TopicInfo_Callback_t Callback, void *OpaqueArg)
 {
     const CFE_MissionLib_InterfaceId_Entry_t *IntfPtr;
-    const CFE_MissionLib_TopicId_Entry_t *TopicPtr;
-    uint16_t TopicId;
+    const CFE_MissionLib_TopicId_Entry_t *    TopicPtr;
+    uint16_t                                  TopicId;
 
     IntfPtr = CFE_MissionLib_Lookup_SubIntf(Intf, InterfaceType);
     if (IntfPtr != NULL)
@@ -527,4 +547,3 @@ void CFE_MissionLib_EnumerateTopics(const CFE_MissionLib_SoftwareBus_Interface_t
         }
     }
 }
-

--- a/cfecfs/missionlib/fsw/src/cfe_missionlib_database_types.h
+++ b/cfecfs/missionlib/fsw/src/cfe_missionlib_database_types.h
@@ -1,23 +1,22 @@
 /*
  * LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
- * 
+ *
  * Copyright (c) 2020 United States Government as represented by
  * the Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 /**
  * \file     cfe_missionlib_database_types.h
@@ -55,22 +54,20 @@ typedef struct CFE_MissionLib_Subcommand_Entry CFE_MissionLib_Subcommand_Entry_t
 
 struct CFE_MissionLib_Command_Definition_Entry
 {
-    uint16_t SubcommandArg;
-    uint16_t SubcommandCount;
-    const struct CFE_MissionLib_Argument_Entry *ArgumentList;
+    uint16_t                                      SubcommandArg;
+    uint16_t                                      SubcommandCount;
+    const struct CFE_MissionLib_Argument_Entry *  ArgumentList;
     const struct CFE_MissionLib_Subcommand_Entry *SubcommandList;
-
 };
 
 typedef struct CFE_MissionLib_Command_Definition_Entry CFE_MissionLib_Command_Definition_Entry_t;
 
-
 struct CFE_MissionLib_TopicId_Entry
 {
-    uint16_t DispatchTableId;
-    uint16_t DispatchStartOffset;
-    uint16_t InterfaceId;
-    const char *TopicName;
+    uint16_t                                         DispatchTableId;
+    uint16_t                                         DispatchStartOffset;
+    uint16_t                                         InterfaceId;
+    const char *                                     TopicName;
     const CFE_MissionLib_Command_Definition_Entry_t *CommandList;
 };
 
@@ -78,7 +75,7 @@ typedef struct CFE_MissionLib_TopicId_Entry CFE_MissionLib_TopicId_Entry_t;
 
 struct CFE_MissionLib_Command_Prototype_Entry
 {
-    uint16_t NumArguments;
+    uint16_t    NumArguments;
     const char *CommandName;
 };
 
@@ -86,21 +83,20 @@ typedef struct CFE_MissionLib_Command_Prototype_Entry CFE_MissionLib_Command_Pro
 
 struct CFE_MissionLib_InterfaceId_Entry
 {
-    uint16_t NumCommands;
-    uint16_t NumTopics;
-    const char *InterfaceName;
+    uint16_t                                        NumCommands;
+    uint16_t                                        NumTopics;
+    const char *                                    InterfaceName;
     const CFE_MissionLib_Command_Prototype_Entry_t *CommandList;
-    const CFE_MissionLib_TopicId_Entry_t *TopicList;
+    const CFE_MissionLib_TopicId_Entry_t *          TopicList;
 };
 
 typedef struct CFE_MissionLib_InterfaceId_Entry CFE_MissionLib_InterfaceId_Entry_t;
 
 struct CFE_MissionLib_SoftwareBus_Interface
 {
-    uint16_t NumInterfaces;
+    uint16_t                                  NumInterfaces;
     const CFE_MissionLib_InterfaceId_Entry_t *InterfaceList;
-    const char * const * InstanceList;
+    const char *const *                       InstanceList;
 };
 
-#endif  /* _CFE_MISSIONLIB_DATABASE_TYPES_H_ */
-
+#endif /* _CFE_MISSIONLIB_DATABASE_TYPES_H_ */

--- a/cfecfs/missionlib/fsw/src/cfe_missionlib_runtime_default.c
+++ b/cfecfs/missionlib/fsw/src/cfe_missionlib_runtime_default.c
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 /**
  * \file     cfe_missionlib_runtime_default.c
  * \ingroup  fsw
@@ -51,8 +50,7 @@
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_missionlib_runtime.h"
 
-
-#define CFE_MISSIONLIB_GETSET_MSGID_BITS(hdr, action, ...) CFE_MissionLib_ ## hdr ## _ ## action (__VA_ARGS__)
+#define CFE_MISSIONLIB_GETSET_MSGID_BITS(hdr, action, ...) CFE_MissionLib_##hdr##_##action(__VA_ARGS__)
 
 #define CFE_MISSIONLIB_GET_MSGID_BITS(hdr, mid, pkt) CFE_MISSIONLIB_GETSET_MSGID_BITS(hdr, BitsToMsgId, mid, pkt)
 #define CFE_MISSIONLIB_SET_MSGID_BITS(hdr, pkt, mid) CFE_MISSIONLIB_GETSET_MSGID_BITS(hdr, BitsFromMsgId, pkt, mid)
@@ -68,32 +66,34 @@
  */
 
 /* Primary header type bits - always used */
-#define CFE_MISSIONLIB_MSGID_TYPE_MASK     0x3     /**< Bit mask to get the CMD/TLM type from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_TYPE_SHIFT    11      /**< Bit shift to get the CMD/TLM type from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_TYPE_MASK  0x3 /**< Bit mask to get the CMD/TLM type from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_TYPE_SHIFT 11  /**< Bit shift to get the CMD/TLM type from MsgId Value */
 
-#define CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS 0x3     /**< Fixed value to set in MsgId for command packets (LSB-justified) */
-#define CFE_MISSIONLIB_MSGID_TELEMETRY_BITS   0x1     /**< Fixed value to set in MsgId for telemetry packets (LSB-justified) */
+#define CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS \
+    0x3 /**< Fixed value to set in MsgId for command packets (LSB-justified) */
+#define CFE_MISSIONLIB_MSGID_TELEMETRY_BITS \
+    0x1 /**< Fixed value to set in MsgId for telemetry packets (LSB-justified) */
 
 /* When using only basic (v1) headers, the TopicID + Subsystem are squeezed into the historical 11-bit field */
 #if CFE_MISSIONLIB_SELECTED_HDRTYPE == CFE_MISSIONLIB_SpacePacketBasic_HEADERS
 
-#define CFE_MISSIONLIB_MSGID_APID_MASK     0x003F  /**< Bit mask to get the APID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_APID_SHIFT    0       /**< Bit shift to get the APID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SUBSYS_MASK   0x001F  /**< Bit mask to get the Subsystem ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT  6       /**< Bit shift to get the Subsystem ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SYS_MASK      0       /**< Bit mask to get the System ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SYS_SHIFT     0       /**< Bit shift to get the System ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_APID_MASK    0x003F /**< Bit mask to get the APID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_APID_SHIFT   0      /**< Bit shift to get the APID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SUBSYS_MASK  0x001F /**< Bit mask to get the Subsystem ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT 6      /**< Bit shift to get the Subsystem ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SYS_MASK     0      /**< Bit mask to get the System ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SYS_SHIFT    0      /**< Bit shift to get the System ID from MsgId Value */
 
 /* When using extended (v2) headers, more of the MsgId bits can be used */
 #elif CFE_MISSIONLIB_SELECTED_HDRTYPE == CFE_MISSIONLIB_SpacePacketApidQ_HEADERS
 
 /* Extended MsgId information - usable when extended headers are enabled, should be all 0 otherwise */
-#define CFE_MISSIONLIB_MSGID_APID_MASK     0x07FF  /**< Bit mask to get the APID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_APID_SHIFT    0       /**< Bit shift to get the APID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SUBSYS_MASK   0x00FF  /**< Bit mask to get the Subsystem ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT  16      /**< Bit shift to get the Subsystem ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SYS_MASK      0x007F  /**< Bit mask to get the System ID from MsgId Value */
-#define CFE_MISSIONLIB_MSGID_SYS_SHIFT     24      /**< Bit shift to get the System ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_APID_MASK    0x07FF /**< Bit mask to get the APID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_APID_SHIFT   0      /**< Bit shift to get the APID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SUBSYS_MASK  0x00FF /**< Bit mask to get the Subsystem ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT 16     /**< Bit shift to get the Subsystem ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SYS_MASK     0x007F /**< Bit mask to get the System ID from MsgId Value */
+#define CFE_MISSIONLIB_MSGID_SYS_SHIFT    24     /**< Bit shift to get the System ID from MsgId Value */
 
 #else
 
@@ -150,7 +150,8 @@ static inline void CFE_MissionLib_SetMsgIdInterfaceType(CFE_SB_MsgId_t *MsgId, u
  * is not required to pack the bits this way, but the shifts/masks used above
  * will produce a MsgId bit pattern comparable to existing versions of CFE.
  */
-static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(CFE_SB_MsgId_t *MsgId, const CCSDS_SpacePacketBasic_t *Packet)
+static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(CFE_SB_MsgId_t *                MsgId,
+                                                               const CCSDS_SpacePacketBasic_t *Packet)
 {
     CFE_SB_MsgId_t ApidPart;
 
@@ -160,7 +161,8 @@ static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(CFE_SB_MsgId_t *M
     CFE_MissionLib_SetMsgIdInterfaceType(MsgId, Packet->CommonHdr.SecHdrFlags);
 }
 
-static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(CCSDS_SpacePacketBasic_t *Packet, const CFE_SB_MsgId_t *MsgId)
+static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(CCSDS_SpacePacketBasic_t *Packet,
+                                                                 const CFE_SB_MsgId_t *    MsgId)
 {
     CFE_SB_MsgId_t ApidPart;
 
@@ -168,13 +170,14 @@ static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(CCSDS_SpacePack
     CFE_MissionLib_SetMsgIdApid(&ApidPart, CFE_MissionLib_GetMsgIdApid(MsgId));
     CFE_MissionLib_SetMsgIdSubsystem(&ApidPart, CFE_MissionLib_GetMsgIdSubsystem(MsgId));
 
-    Packet->CommonHdr.VersionId = 0;
-    Packet->CommonHdr.AppId = ApidPart.Value;
+    Packet->CommonHdr.VersionId   = 0;
+    Packet->CommonHdr.AppId       = ApidPart.Value;
     Packet->CommonHdr.SecHdrFlags = CFE_MissionLib_GetMsgIdInterfaceType(MsgId);
 }
 
 /* The following translations apply only for V2 (ApidQ) headers */
-static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(CFE_SB_MsgId_t *MsgId, const CCSDS_SpacePacketApidQ_t *Packet)
+static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(CFE_SB_MsgId_t *                MsgId,
+                                                               const CCSDS_SpacePacketApidQ_t *Packet)
 {
     CFE_MissionLib_SetMsgIdApid(MsgId, Packet->CommonHdr.AppId);
     CFE_MissionLib_SetMsgIdInterfaceType(MsgId, Packet->CommonHdr.SecHdrFlags);
@@ -182,32 +185,24 @@ static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(CFE_SB_MsgId_t *M
     CFE_MissionLib_SetMsgIdSubsystem(MsgId, Packet->ApidQ.SubsystemId);
 }
 
-static inline void CFE_MissionLib_SpacePacketApidQ_BitsFromMsgId(CCSDS_SpacePacketApidQ_t *Packet, const CFE_SB_MsgId_t *MsgId)
+static inline void CFE_MissionLib_SpacePacketApidQ_BitsFromMsgId(CCSDS_SpacePacketApidQ_t *Packet,
+                                                                 const CFE_SB_MsgId_t *    MsgId)
 {
-    Packet->CommonHdr.VersionId = 1;
-    Packet->CommonHdr.AppId = CFE_MissionLib_GetMsgIdApid(MsgId);
+    Packet->CommonHdr.VersionId   = 1;
+    Packet->CommonHdr.AppId       = CFE_MissionLib_GetMsgIdApid(MsgId);
     Packet->CommonHdr.SecHdrFlags = CFE_MissionLib_GetMsgIdInterfaceType(MsgId);
-    Packet->ApidQ.SystemId = CFE_MissionLib_GetMsgIdSystem(MsgId);
-    Packet->ApidQ.SubsystemId = CFE_MissionLib_GetMsgIdSubsystem(MsgId);
+    Packet->ApidQ.SystemId        = CFE_MissionLib_GetMsgIdSystem(MsgId);
+    Packet->ApidQ.SubsystemId     = CFE_MissionLib_GetMsgIdSubsystem(MsgId);
 }
 
-#ifdef jphfix
-/*
- * This is a configuration error.  The only base types currently supported by this implementation
- * are "SpacePacketBasic" and "SpacePacketApidQ".  The configuration can either be corrected, or
- * support for the other header type must be added.
- */
-#error "MsgId Mappings not defined for this header style"
-#endif
-
-
-void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output, const CFE_SB_Listener_Component_t *Input)
+void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
+                                         const CFE_SB_Listener_Component_t *    Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (Input->Telecommand.InstanceNumber <=  CFE_MISSIONLIB_MSGID_SUBSYS_MASK &&
-            Input->Telecommand.TopicId >= CFE_MISSION_TELECOMMAND_BASE_TOPICID &&
-            Input->Telecommand.TopicId < CFE_MISSION_TELECOMMAND_MAX_TOPICID)
+    if (Input->Telecommand.InstanceNumber <= CFE_MISSIONLIB_MSGID_SUBSYS_MASK &&
+        Input->Telecommand.TopicId >= CFE_MISSION_TELECOMMAND_BASE_TOPICID &&
+        Input->Telecommand.TopicId < CFE_MISSION_TELECOMMAND_MAX_TOPICID)
     {
         CFE_MissionLib_SetMsgIdInterfaceType(&Output->MsgId, CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS);
         CFE_MissionLib_SetMsgIdApid(&Output->MsgId, Input->Telecommand.TopicId - CFE_MISSION_TELECOMMAND_BASE_TOPICID);
@@ -215,7 +210,8 @@ void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *
     }
 }
 
-void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *Output, const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *                Output,
+                                           const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
 {
     memset(Output, 0, sizeof(*Output));
 
@@ -231,13 +227,14 @@ bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_I
     return (CFE_MissionLib_GetMsgIdInterfaceType(&Params->MsgId) == CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS);
 }
 
-void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output, const CFE_SB_Publisher_Component_t *Input)
+void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
+                                          const CFE_SB_Publisher_Component_t *   Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (Input->Telemetry.InstanceNumber <=  CFE_MISSIONLIB_MSGID_SUBSYS_MASK &&
-            Input->Telemetry.TopicId >= CFE_MISSION_TELEMETRY_BASE_TOPICID &&
-            Input->Telemetry.TopicId < CFE_MISSION_TELEMETRY_MAX_TOPICID)
+    if (Input->Telemetry.InstanceNumber <= CFE_MISSIONLIB_MSGID_SUBSYS_MASK &&
+        Input->Telemetry.TopicId >= CFE_MISSION_TELEMETRY_BASE_TOPICID &&
+        Input->Telemetry.TopicId < CFE_MISSION_TELEMETRY_MAX_TOPICID)
     {
         CFE_MissionLib_SetMsgIdInterfaceType(&Output->MsgId, CFE_MISSIONLIB_MSGID_TELEMETRY_BITS);
         CFE_MissionLib_SetMsgIdApid(&Output->MsgId, Input->Telemetry.TopicId - CFE_MISSION_TELEMETRY_BASE_TOPICID);
@@ -245,7 +242,8 @@ void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t 
     }
 }
 
-void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *Output, const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *               Output,
+                                            const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
 {
     memset(Output, 0, sizeof(*Output));
 
@@ -261,138 +259,15 @@ bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_
     return (CFE_MissionLib_GetMsgIdInterfaceType(&Params->MsgId) == CFE_MISSIONLIB_MSGID_TELEMETRY_BITS);
 }
 
-void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params, const CFE_HDR_Message_t *Packet)
+void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params,
+                                          const CFE_HDR_Message_t *              Packet)
 {
     memset(Params, 0, sizeof(*Params));
     CFE_MISSIONLIB_GET_MSGID_BITS(CFE_MISSION_MSG_HEADER_TYPE, &Params->MsgId, &Packet->CCSDS);
 }
 
-void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *Packet, const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                          Packet,
+                                          const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
 {
     CFE_MISSIONLIB_SET_MSGID_BITS(CFE_MISSION_MSG_HEADER_TYPE, &Packet->CCSDS, &Params->MsgId);
 }
-
-#ifdef jphfix
-/*----------------------------------------------------------------
- *
- * Function: CFE_MSG_GetTypeFromMsgId
- *
- * Implemented per public API
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
-{
-    CFE_SB_MsgIdValue_Atom_t Value;
-
-    if (Type == NULL)
-    {
-        return CFE_MSG_BAD_ARGUMENT;
-    }
-
-    Value = CFE_SB_MsgIdToValue(MsgId);
-
-    /* determine if cmd/tlm from base msgid bits */
-    switch ((Value >> CFE_MISSIONLIB_MSGID_TYPE_SHIFT) & CFE_MISSIONLIB_MSGID_TYPE_MASK)
-    {
-        case CFE_MISSIONLIB_MSGID_TLM_BITS:
-            *Type = CFE_MSG_Type_Tlm;
-            break;
-        case CFE_MISSIONLIB_MSGID_CMD_BITS:
-            *Type = CFE_MSG_Type_Cmd;
-            break;
-        default:
-            *Type = CFE_MSG_Type_Invalid;
-            break;
-    }
-
-    return CFE_SUCCESS;
-}
-
-CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
-{
-    CFE_SB_MsgIdValue_Atom_t Value;
-    CFE_Status_t Status;
-
-    if (MsgPtr == NULL || MsgId == NULL)
-    {
-        return CFE_MSG_BAD_ARGUMENT;
-    }
-
-    Status = CFE_SUCCESS;
-    Value = 0;
-
-    /* determine if cmd/tlm and set base msgid bits */
-    switch (MsgPtr->Meta.Type)
-    {
-        case CFE_MSG_Type_Tlm:
-            Value |= CFE_MISSIONLIB_MSGID_TLM_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT;
-            break;
-        case CFE_MSG_Type_Cmd:
-            Value |= CFE_MISSIONLIB_MSGID_CMD_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT;
-            break;
-        default:
-            /* this can happen if e.g. an uninitialized msg is passed in */
-            Status = CFE_MSG_BAD_ARGUMENT;
-            break;
-    }
-
-    /* fill in all other bit fields if successful */
-    if (Status == CFE_SUCCESS)
-    {
-        if (CFE_MISSIONLIB_MSGID_SHDR_MASK != 0 && MsgPtr->Meta.HasSecondary)
-        {
-            Value |= CFE_MISSIONLIB_MSGID_SHDR_MASK << CFE_MISSIONLIB_MSGID_SHDR_SHIFT;
-        }
-
-        Value |= (MsgPtr->Meta.ApId & CFE_MISSIONLIB_MSGID_APID_MASK) << CFE_MISSIONLIB_MSGID_APID_SHIFT;
-        Value |= (MsgPtr->Meta.Subsystem & CFE_MISSIONLIB_MSGID_SUBSYS_MASK) << CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT;
-        Value |= (MsgPtr->Meta.System & CFE_MISSIONLIB_MSGID_SYS_MASK) << CFE_MISSIONLIB_MSGID_SYS_SHIFT;
-    }
-
-    *MsgId = CFE_SB_ValueToMsgId(Value);
-
-    return Status;
-}
-
-CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
-{
-    CFE_SB_MsgIdValue_Atom_t Value;
-    CFE_MSG_Type_t IdType;
-    CFE_Status_t Status;
-
-    if (MsgPtr == NULL)
-    {
-        return CFE_MSG_BAD_ARGUMENT;
-    }
-
-    /* determine if cmd/tlm from base msgid bits */
-    Status = CFE_MSG_GetTypeFromMsgId(MsgId, &IdType);
-
-    /* extract all other bit fields if successful */
-    if (Status == CFE_SUCCESS && IdType != CFE_MSG_Type_Invalid)
-    {
-        Value = CFE_SB_MsgIdToValue(MsgId);
-
-        MsgPtr->Meta.Type = IdType; /* note this may change the interpretation of secondary header fields */
-
-        /* Secondary should always be present for CFE SB use, but CCSDS does not require it */
-        if (CFE_MISSIONLIB_MSGID_SHDR_MASK == 0)
-        {
-            /* No bit in MsgId for sechdr presence; assume always present */
-            MsgPtr->Meta.HasSecondary = true;
-        }
-        else
-        {
-            MsgPtr->Meta.HasSecondary = (Value >> CFE_MISSIONLIB_MSGID_SHDR_SHIFT) & CFE_MISSIONLIB_MSGID_SHDR_MASK;
-        }
-
-
-        MsgPtr->Meta.ApId = (Value >> CFE_MISSIONLIB_MSGID_APID_SHIFT) & CFE_MISSIONLIB_MSGID_APID_MASK;
-        MsgPtr->Meta.Subsystem = (Value >> CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT) & CFE_MISSIONLIB_MSGID_SUBSYS_MASK;
-        MsgPtr->Meta.System = (Value >> CFE_MISSIONLIB_MSGID_SYS_SHIFT) & CFE_MISSIONLIB_MSGID_SYS_MASK;
-    }
-
-    return Status;
-}
-#endif

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_api_handlers.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_api_handlers.c
@@ -33,9 +33,11 @@
  * Handler function for CFE_MissionLib_FindCommandByName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_FindCommandByName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_FindCommandByName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                        const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "CommandIdBuffer", uint16_t *), sizeof(uint16_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "CommandIdBuffer", uint16_t *), sizeof(uint16_t));
 }
 
 /*
@@ -43,9 +45,11 @@ void UT_DefaultHandler_CFE_MissionLib_FindCommandByName(void *UserObj, UT_EntryK
  * Handler function for CFE_MissionLib_FindInterfaceByName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_FindInterfaceByName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_FindInterfaceByName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                          const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "InterfaceIdBuffer", uint16_t *), sizeof(uint16_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "InterfaceIdBuffer", uint16_t *), sizeof(uint16_t));
 }
 
 /*
@@ -53,9 +57,11 @@ void UT_DefaultHandler_CFE_MissionLib_FindInterfaceByName(void *UserObj, UT_Entr
  * Handler function for CFE_MissionLib_FindTopicByName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_FindTopicByName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_FindTopicByName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                      const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "TopicIdBuffer", uint16_t *), sizeof(uint16_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "TopicIdBuffer", uint16_t *), sizeof(uint16_t));
 }
 
 /*
@@ -63,9 +69,11 @@ void UT_DefaultHandler_CFE_MissionLib_FindTopicByName(void *UserObj, UT_EntryKey
  * Handler function for CFE_MissionLib_GetArgumentType()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetArgumentType(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetArgumentType(void *UserObj, UT_EntryKey_t FuncKey,
+                                                      const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Id", EdsLib_Id_t *), sizeof(EdsLib_Id_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Id", EdsLib_Id_t *),
+                                          sizeof(EdsLib_Id_t));
 }
 
 /*
@@ -73,9 +81,12 @@ void UT_DefaultHandler_CFE_MissionLib_GetArgumentType(void *UserObj, UT_EntryKey
  * Handler function for CFE_MissionLib_GetIndicationInfo()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetIndicationInfo(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetIndicationInfo(void *UserObj, UT_EntryKey_t FuncKey,
+                                                        const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "IndInfo", CFE_MissionLib_IndicationInfo_t *), sizeof(CFE_MissionLib_IndicationInfo_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "IndInfo", CFE_MissionLib_IndicationInfo_t *),
+        sizeof(CFE_MissionLib_IndicationInfo_t));
 }
 
 /*
@@ -83,9 +94,12 @@ void UT_DefaultHandler_CFE_MissionLib_GetIndicationInfo(void *UserObj, UT_EntryK
  * Handler function for CFE_MissionLib_GetInterfaceInfo()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetInterfaceInfo(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetInterfaceInfo(void *UserObj, UT_EntryKey_t FuncKey,
+                                                       const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "IntfInfo", CFE_MissionLib_InterfaceInfo_t *), sizeof(CFE_MissionLib_InterfaceInfo_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "IntfInfo", CFE_MissionLib_InterfaceInfo_t *),
+        sizeof(CFE_MissionLib_InterfaceInfo_t));
 }
 
 /*
@@ -93,9 +107,11 @@ void UT_DefaultHandler_CFE_MissionLib_GetInterfaceInfo(void *UserObj, UT_EntryKe
  * Handler function for CFE_MissionLib_GetSubcommandOffset()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetSubcommandOffset(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetSubcommandOffset(void *UserObj, UT_EntryKey_t FuncKey,
+                                                          const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Offset", uint16_t *), sizeof(uint16_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Offset", uint16_t *),
+                                          sizeof(uint16_t));
 }
 
 /*
@@ -103,9 +119,12 @@ void UT_DefaultHandler_CFE_MissionLib_GetSubcommandOffset(void *UserObj, UT_Entr
  * Handler function for CFE_MissionLib_GetTopicInfo()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetTopicInfo(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetTopicInfo(void *UserObj, UT_EntryKey_t FuncKey,
+                                                   const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "TopicInfo", CFE_MissionLib_TopicInfo_t *), sizeof(CFE_MissionLib_TopicInfo_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
+                                          UT_Hook_GetArgValueByName(Context, "TopicInfo", CFE_MissionLib_TopicInfo_t *),
+                                          sizeof(CFE_MissionLib_TopicInfo_t));
 }
 
 /*
@@ -113,7 +132,8 @@ void UT_DefaultHandler_CFE_MissionLib_GetTopicInfo(void *UserObj, UT_EntryKey_t 
  * Handler function for CFE_MissionLib_GetCommandName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetCommandName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetCommandName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                     const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultStringOutput(FuncKey, Context);
 }
@@ -123,7 +143,8 @@ void UT_DefaultHandler_CFE_MissionLib_GetCommandName(void *UserObj, UT_EntryKey_
  * Handler function for CFE_MissionLib_GetInterfaceName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetInterfaceName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetInterfaceName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                       const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultStringOutput(FuncKey, Context);
 }
@@ -133,7 +154,8 @@ void UT_DefaultHandler_CFE_MissionLib_GetInterfaceName(void *UserObj, UT_EntryKe
  * Handler function for CFE_MissionLib_GetInstanceName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetInstanceName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetInstanceName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                      const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultStringOutput(FuncKey, Context);
 }
@@ -143,9 +165,10 @@ void UT_DefaultHandler_CFE_MissionLib_GetInstanceName(void *UserObj, UT_EntryKey
  * Handler function for CFE_MissionLib_GetInstanceNumber()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetInstanceNumber(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetInstanceNumber(void *UserObj, UT_EntryKey_t FuncKey,
+                                                        const UT_StubContext_t *Context)
 {
-    int32_t Status;
+    int32_t  Status;
     uint16_t Result;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
@@ -158,7 +181,8 @@ void UT_DefaultHandler_CFE_MissionLib_GetInstanceNumber(void *UserObj, UT_EntryK
  * Handler function for CFE_MissionLib_GetTopicName()
  * ----------------------------------------------------
  */
-void UT_DefaultHandler_CFE_MissionLib_GetTopicName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_GetTopicName(void *UserObj, UT_EntryKey_t FuncKey,
+                                                   const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultStringOutput(FuncKey, Context);
 }

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_handlers.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_handlers.c
@@ -33,10 +33,11 @@
  * Default handler for CFE_MissionLib_PubSub_IsListenerComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_PubSub_IsListenerComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_PubSub_IsListenerComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                                 const UT_StubContext_t *Context)
 {
-    int32      status;
-    bool       result;
+    int32 status;
+    bool  result;
 
     UT_Stub_GetInt32StatusCode(Context, &status);
     result = (status != 0);
@@ -49,10 +50,11 @@ void UT_DefaultHandler_CFE_MissionLib_PubSub_IsListenerComponent(void *UserObj, 
  * Default handler for CFE_MissionLib_PubSub_IsPublisherComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_PubSub_IsPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_PubSub_IsPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                                  const UT_StubContext_t *Context)
 {
-    int32      status;
-    bool       result;
+    int32 status;
+    bool  result;
 
     UT_Stub_GetInt32StatusCode(Context, &status);
     result = (status != 0);
@@ -60,15 +62,17 @@ void UT_DefaultHandler_CFE_MissionLib_PubSub_IsPublisherComponent(void *UserObj,
     UT_Stub_SetReturnValue(FuncKey, result);
 }
 
-
 /*------------------------------------------------------------
  *
  * Default handler for CFE_MissionLib_MapListenerComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                           const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *), sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *),
+        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
 }
 
 /*------------------------------------------------------------
@@ -76,9 +80,12 @@ void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *UserObj, UT_Ent
  * Default handler for CFE_MissionLib_UnmapListenerComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                             const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Listener_Component_t *), sizeof(CFE_SB_Listener_Component_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
+                                          UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Listener_Component_t *),
+                                          sizeof(CFE_SB_Listener_Component_t));
 }
 
 /*------------------------------------------------------------
@@ -86,9 +93,12 @@ void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *UserObj, UT_E
  * Default handler for CFE_MissionLib_MapPublisherComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                            const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *), sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *),
+        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
 }
 
 /*------------------------------------------------------------
@@ -96,9 +106,12 @@ void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *UserObj, UT_En
  * Default handler for CFE_MissionLib_UnmapPublisherComponent coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey,
+                                                              const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Publisher_Component_t *), sizeof(CFE_SB_Publisher_Component_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
+                                          UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Publisher_Component_t *),
+                                          sizeof(CFE_SB_Publisher_Component_t));
 }
 
 /*------------------------------------------------------------
@@ -106,9 +119,12 @@ void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *UserObj, UT_
  * Default handler for CFE_MissionLib_Get_PubSub_Parameters coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *UserObj, UT_EntryKey_t FuncKey,
+                                                            const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Params", CFE_SB_SoftwareBus_PubSub_Interface_t *), sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Params", CFE_SB_SoftwareBus_PubSub_Interface_t *),
+        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
 }
 
 /*------------------------------------------------------------
@@ -116,7 +132,9 @@ void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *UserObj, UT_En
  * Default handler for CFE_MissionLib_Set_PubSub_Parameters coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters(void *UserObj, UT_EntryKey_t FuncKey,
+                                                            const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Packet", CFE_HDR_Message_t *), sizeof(CFE_HDR_Message_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Packet", CFE_HDR_Message_t *), sizeof(CFE_HDR_Message_t));
 }

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_stub_helpers.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_stub_helpers.c
@@ -27,7 +27,8 @@
 #include "utstubs.h"
 #include "utassert.h"
 
-void CFE_MissionLib_Stub_DefaultZeroOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, void *OutputBuffer, size_t OutputSize)
+void CFE_MissionLib_Stub_DefaultZeroOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, void *OutputBuffer,
+                                           size_t OutputSize)
 {
     int32_t Status;
 
@@ -44,9 +45,9 @@ void CFE_MissionLib_Stub_DefaultZeroOutput(UT_EntryKey_t FuncKey, const UT_StubC
 
 void CFE_MissionLib_Stub_DefaultStringOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    int32_t Status;
-    void *DataBuffer;
-    const char *Result;
+    int32_t           Status;
+    void *            DataBuffer;
+    const char *      Result;
     static const char DEFAULT_OUTPUT[] = "UT";
 
     UT_Stub_GetInt32StatusCode(Context, &Status);

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_stub_helpers.h
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_stub_helpers.h
@@ -29,7 +29,8 @@
 #include "utstubs.h"
 #include "utassert.h"
 
-void CFE_MissionLib_Stub_DefaultZeroOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, void *OutputBuffer, size_t OutputSize);
+void CFE_MissionLib_Stub_DefaultZeroOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, void *OutputBuffer,
+                                           size_t OutputSize);
 void CFE_MissionLib_Stub_DefaultStringOutput(UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
 
 #endif /* CFE_MISSIONLIB_STUB_HELPERS_H */


### PR DESCRIPTION
The EDS Caelum build to this point has been missing the EDS-based message dispatcher.  This change re-adds the missing feature and also cleans up other items to bring the build up to par with the previous version.

Fixes #18
Fixes #19
