### PR TITLE
Fix #23, update cmake minimum to 3.5

### DIFF
--- a/cfecfs/missionlib/CMakeLists.txt
+++ b/cfecfs/missionlib/CMakeLists.txt
@@ -1,17 +1,17 @@
 #
 # LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
 # LEW-20211-1, Python Bindings for the Core Flight Executive Mission Library
-# 
+#
 # Copyright (c) 2020 United States Government as represented by
 # the Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@
 # subdirectory.  The contents of this directory should be included on the sedstool command
 # line which is handled outside of this script.
 #
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(EDS_CFECFS_MISSIONLIB C)
 
 
@@ -175,4 +175,3 @@ endif (SUPPORTS_SHARED_LIBS)
 add_subdirectory(fsw)
 add_subdirectory(lua)
 add_subdirectory(python)
-

--- a/edslib/CMakeLists.txt
+++ b/edslib/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
-# 
+#
 # Copyright (c) 2020 United States Government as represented by
 # the Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 project(EDSLIB C)
 
 #
@@ -141,4 +141,3 @@ add_subdirectory(fsw)
 add_subdirectory(lua)
 add_subdirectory(json)
 add_subdirectory(python)
-

--- a/edslib/fsw/CMakeLists.txt
+++ b/edslib/fsw/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
-# 
+#
 # Copyright (c) 2020 United States Government as represented by
 # the Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -88,7 +88,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.5)
 project(EDSLIB_FSW C)
 
 enable_testing()
@@ -225,4 +225,3 @@ endif(IS_CFS_MISSION_BUILD)
 if (ENABLE_UNIT_TESTS AND IS_CFS_ARCH_BUILD)
   add_subdirectory(ut-stubs)
 endif (ENABLE_UNIT_TESTS AND IS_CFS_ARCH_BUILD)
-

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
 # LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
-# 
+#
 # Copyright (c) 2020 United States Government as represented by
 # the Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@
 # tools are linked into the final executables, but there is no dependency
 # on expat in the final binaries.
 #
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.5)
 project(EDSTOOL C)
 
 add_definitions(-Wall -Werror -std=c99 -pedantic)
@@ -82,4 +82,3 @@ target_link_libraries(sedstool
     ${EXPAT_LIB}
     dl
 )
-


### PR DESCRIPTION
Updates the `cmake_minimum_required()` to version 3.5, to match CFE and avoid a warning.