### PR TITLE
Fix #47, remove excess comma in JSON command output

### DIFF
--- a/cfecfs/missionlib/eds/90-write_ccdd_json.lua
+++ b/cfecfs/missionlib/eds/90-write_ccdd_json.lua
@@ -169,7 +169,6 @@ for _,instance in ipairs(SEDS.highlevel_interfaces) do
         output:write(string.format("\"%smid_name\": \"%s\",", prefix, msgid))
         output:write(string.format("\"%sdescription\": \"%s\",", prefix, reqintf.attributes.shortdescription or ""))
         if (cmd.cc_list) then
-          output:append_previous(",")
           output:start_group("\"cmd_codes\": [")
           for _,cc in ipairs(cmd.cc_list) do
             output:append_previous(",")


### PR DESCRIPTION
**Describe the contribution**
A comma was being appended twice to the command description in JSON output.

Fixes #47

**Testing performed**
Build JSON outputs, check result

**Expected behavior changes**
No more surplus comma

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
