### PR TITLE
Fix #48, no input passed to table tool

### DIFF
--- a/cfecfs/eds2cfetbl/eds2cfetbl.c
+++ b/cfecfs/eds2cfetbl/eds2cfetbl.c
@@ -505,6 +505,13 @@ int main(int argc, char *argv[])
        }
     }
 
+    /* All additional args are input files.  If none, this should be considered an error */
+    if (optind >= argc)
+    {
+        fprintf(stderr, "ERROR: No input files specified on command line.\n");
+        return EXIT_FAILURE;
+    }
+
     /* The CPUNAME and CPUNUMBER variables should both be defined.
      * If only one was provided then look up the other value in EDS */
     lua_getglobal(lua, "CPUNAME");


### PR DESCRIPTION
**Describe the contribution**
Return an error code (EXIT_FAILURE) if no input files were passed to the eds2cfetbl tool.  This points to an error in the parent script/makefile that should be addressed and thus the build should stop.  With a success return, the build keeps running as if everything is OK but there will be no table files at the end.

Fixes #48

**Testing performed**
Build CFE and check table outputs

**Expected behavior changes**
If passed no inputs, this will now exit with a failure code and stop the parent script/makefile

**System(s) tested on**
Debian

**Additional context**
Avoids getting build success with mysteriously missing tables in the case of a scripting error

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
