### PR TITLE
Fix #49, add header init macro

### DIFF
--- a/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
+++ b/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
@@ -62,6 +62,23 @@
  */
 #define CFE_MSG_PTR(shdr) ((void *)(&(shdr)))
 
+/**
+ * \brief Macro to initialize a command header, useful in tables that define commands
+ */
+#define CFE_MSG_CMD_HDR_INIT(mid, size, fc, cksum)             \
+    {                                                          \
+        .CommandHeader = {                                     \
+            .Message.CCSDS.CommonHdr =                         \
+                {                                              \
+                    .SecHdrFlags = (mid) >> 11,                \
+                    .AppId       = (mid)&0x7FF,                \
+                    .SeqFlag     = 0x03,                       \
+                    .Length      = (size),                     \
+                },                                             \
+            .Sec = {.FunctionCode = (fc), .Checksum = (cksum)} \
+        }                                                      \
+    }
+
 /*
  * Type Definitions
  */


### PR DESCRIPTION
**Describe the contribution**
Adds a `CFE_MSG_CMD_HDR_INIT` macro to the EDS header implementation, for parity with the default MSG module.

Fixes #49

**Testing performed**
Build HS tables using this macro

**Expected behavior changes**
Compatibility with existing table definitions

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
