### PR TITLE
Fix #56, Update out-of-sync function paramater names and correct typos

### DIFF
--- a/cfecfs/edsmsg/eds/cfe_hdr.xml
+++ b/cfecfs/edsmsg/eds/cfe_hdr.xml
@@ -24,7 +24,7 @@
 
     Purpose:
       This describes usage of objects as defined by CCSDS book 133 Space Packet Protocol,
-      as utilized by the Core Fligh System (cFS)
+      as utilized by the Core Flight System (cFS)
 
 -->
 <PackageFile xmlns="http://www.ccsds.org/schema/sois/seds">
@@ -41,7 +41,7 @@
 
       <IntegerDataType name="FunctionCode" shortDescription="The command ID contained within a command secondary header">
         <LongDescription>
-          Command codes in CFE range are 7 bits (0-127).  The most signficant bit (codes 128-255) are reserved.
+          Command codes in CFE range are 7 bits (0-127). The most significant bit (codes  128-255) are reserved.
         </LongDescription>
         <IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
         <Range>

--- a/cfecfs/missionlib/eds/90-write_intf_hierarchy.lua
+++ b/cfecfs/missionlib/eds/90-write_intf_hierarchy.lua
@@ -20,7 +20,7 @@
 
 -- ---------------------------------------------
 -- generate interface hierarchy graphic
--- This generates dot files based on the interface heirarchy which can be
+-- This generates dot files based on the interface hierarchy which can be
 -- easily turned into graphics using the "dot" tool.
 -- This script should run late in the processing stages
 -- ---------------------------------------------

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
@@ -26,7 +26,7 @@
 ** Author: mathew.j.mccaskey@nasa.gov
 **
 ** Purpose:
-**   Implement python type which represents an CFE_MissionLib database
+**   Implement python type which represents a CFE_MissionLib database
 **
 **   Allows python code to dynamically load a database object and retrieve
 **   entries from it.

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_interface.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_interface.c
@@ -367,7 +367,7 @@ static PyObject *CFE_MissionLib_Python_Interface_gettopic(PyObject *obj, PyObjec
     return result;
 }
 
-PyObject *CFE_MissionLib_Python_Interface_GetFromIntfName(CFE_MissionLib_Python_Database_t *dbobj, PyObject *IntfName)
+PyObject *CFE_MissionLib_Python_Interface_GetFromIntfName(CFE_MissionLib_Python_Database_t *obj, PyObject *InterfaceName)
 {
     int32_t status;
     uint16_t InterfaceId;

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_topic.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_topic.c
@@ -389,7 +389,7 @@ PyObject *CFE_MissionLib_Python_Topic_repr(PyObject *obj)
     return PyUnicode_FromFormat("%s(%R,%R,%R)", obj->ob_type->tp_name, self->IntfObj->DbObj->DbName, self->IntfObj->IntfName, self->TopicName);
 }
 
-PyObject *CFE_MissionLib_Python_Topic_GetFromTopicName(CFE_MissionLib_Python_Interface_t *intfobj, PyObject *TopicName)
+PyObject *CFE_MissionLib_Python_Topic_GetFromTopicName(CFE_MissionLib_Python_Interface_t *obj, PyObject *TopicName)
 {
     CFE_MissionLib_Python_Topic_t *TopicEntry;
 

--- a/doc/eds-dom-reference.md
+++ b/doc/eds-dom-reference.md
@@ -76,7 +76,7 @@ flight software; much of the logic is actually very generic.
 
 ### Application-independent Basic Reading and Preprocessing
 
-The basic tool in the `tool` subdirectory only provides an execution enviroment and
+The basic tool in the `tool` subdirectory only provides an execution environment and
 some preprocessing scripts.  It handles the task of reading the XML files and building
 a "Document Object Model" (DOM) tree in memory.
 
@@ -131,7 +131,7 @@ representation and the native representation of an object, using the generated m
 tables.  This foundation also acts as the basis for bindings to other higher level languages.  Two
 such bindings are provided, to Lua and JSON, in the `lua` and `json` directories, respectively.
 These leverage third party libraries that convert between "C" language values and the corresponding
-script languge.  Additional bindings can be easily added, such as Ruby or Python, as necessary.
+script language.  Additional bindings can be easily added, such as Ruby or Python, as necessary.
 
 __Scripts Provided__
 
@@ -195,7 +195,7 @@ __Scripts Provided__
 | `cfe_sb_parameter_map`     | Determine parameter values for all interface instances            |
 | `cfe_sb_dispatch_tables`   | Write C source files for dispatching software bus messages        |
 | `build_cfe_sb_interfacedb` | Write makefiles to build objects                                  |
-| `write_intf_heirarchy`     | Create dot files to graphically view the interface structure      |
+| `write_intf_hierarchy`     | Create dot files to graphically view the interface structure      |
 
 
 
@@ -212,7 +212,7 @@ dependency relationship between the two scripts.  If one script needs to execute
 before the other, scripts would need to be re-numbered to ensure correct ordering.
 
 
-# SEDS Tool Runtime Enviornment
+# SEDS Tool Runtime Environment
 
 All SEDS processing operations are implemented in Lua, and the basic tool provides an
 execution environment for these Lua scripts, calling each user-specified script in sequence.
@@ -294,7 +294,7 @@ connections have been consolidated for the sake of illustration.
 
 ### Example Interface Tree
 
-In order to make use of the interfaces described in EDS, the tool also generates an "interface heirarchy"
+In order to make use of the interfaces described in EDS, the tool also generates an "interface hierarchy"
 similar in structure to the DOM tree shown above.  While the DOM tree focuses on _definitions_, this tree
 describes actual _instances_ of the components described in EDS.
 
@@ -399,14 +399,14 @@ are worth noting here as they may be relevant to additional script development.
 ### Console output and reporting functions
 
 The following functions simplify the process of reporting status information to the user console.
-Thes can abstract different output/terminal environments and add context information (e.g. to format
+These can abstract different output/terminal environments and add context information (e.g. to format
 error messages such that IDE environments can automatically link to the relevant source file), and
 also give the user control over how the messages are ultimately displayed:
 
 | Function              | Purpose                                                       |
 |-----------------------|---------------------------------------------------------------|
 | `debug`               | Generate a "Debug" message to the console                     |
-| `info`                | Generate an "Information" messsage                            |
+| `info`                | Generate an "Information" message                            |
 | `warning`             | Generate a "Warning" message                                  |
 | `error`               | Generate an "Error" message                                   |
 | `fatal`               | Generate a "Fatal" message, **causes tool to abort**          |
@@ -439,10 +439,10 @@ This set of functions is provided as general purpose utilities:
 
 **NOTE**: The `sorted_keys` function operates on any standard Lua table and it is not specific
 to EDS processing in any way.  It is included here because the standard Lua table iteration
-function `pairs()` does not return the keys in a predicable or consistent order.  However,
+function `pairs()` does not return the keys in a predictable or consistent order.  However,
 ordering is often important when generating EDS output files, as one typically wants to produce
-consistent output between subsequent executions of the tool, to avoid superflous file changes.
-Obtaining the keys to a table in a consistent order is an important tool for acheving this goal.
+consistent output between subsequent executions of the tool, to avoid superfluous file changes.
+Obtaining the keys to a table in a consistent order is an important tool for achieving this goal.
 
 
 ### Output file generation functions
@@ -472,7 +472,7 @@ The filehandle returned from `SEDS.output_open` contains the following additiona
 **NOTE**: The `append_previous` method is used assist when generating line-oriented lists, where
 every line except the last element would have a comma.  In general, it is not known which
 type of punctuation to use on a given line until the _next_ line is generated.  This necessitates
-either putting the punctuation at the beginning of the next line, which is less readble, or by
+either putting the punctuation at the beginning of the next line, which is less readable, or by
 "peeking" ahead, which is tedious.  This method is a compromise that allows the line punctuation
 to be modified after the initial write.
 
@@ -482,7 +482,7 @@ to be modified after the initial write.
 General purpose filtering functions accept a single DOM node reference and return a boolean
 value indicating whether the node matches the filtering criteria.  A number of commonly-used
 filter criteria are available as predefined filters.  Additionally, a "factory" function is
-provided to simpify the process of creating new filters which match any arbitrary node type.
+provided to simplify the process of creating new filters which match any arbitrary node type.
 
 | Filter Factory Function    | Purpose                                                         |
 |----------------------------|-----------------------------------------------------------------|
@@ -522,7 +522,7 @@ usually _not_ need to perform this type of activity, but these are included for 
 ## Tree Node Property Reference
 
 Each node in the DOM tree have their own methods and properties associated with them.  The base
-tool creates the tree and intializes a basic set of properties on every node, based on the contents
+tool creates the tree and initializes a basic set of properties on every node, based on the contents
 of the XML source and the determined relationships between nodes.
 
 **NOTE**: Properties are dynamic and can be added, modified, or removed by any processing script.
@@ -643,7 +643,7 @@ Methods on `memreq` objects are:
 
 1) all properties are read-only, at least directly.  They are only modified via method calls above.
 2) the "checksum" is a 64-bit integer value.  This exceeds the quantity which can be reliably stored in a Lua number,
-   so it is reprensented as a hexadecimal ASCII string instead.  The string is always 16 characters long.
+   so it is represented as a hexadecimal ASCII string instead.  The string is always 16 characters long.
    
 
 ## Properties added during constraint resolution

--- a/edslib/CMakeLists.txt
+++ b/edslib/CMakeLists.txt
@@ -68,7 +68,7 @@ function(find_edslib_dependency DEPNAME HEADER_FILE)
 
     # Fallback method for cross-compilation or when pkgconfig is not available.
     # NOTE: This method does not verify version of the library.  In a cross-compile
-    # enviornment it will just use whatever version is present in CMAKE_FIND_ROOT_PATH.
+    # environment it will just use whatever version is present in CMAKE_FIND_ROOT_PATH.
 
     # Attempt to get the real library name by stripping any version info from the args
     set(BASENAMES)

--- a/edslib/Doxyfile
+++ b/edslib/Doxyfile
@@ -1655,7 +1655,7 @@ PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 
 # If the CLASS_DIAGRAMS tag is set to YES (the default) Doxygen will 
-# generate a inheritance diagram (in HTML, RTF and LaTeX) for classes with base 
+# generate an inheritance diagram (in HTML, RTF and LaTeX) for classes with base 
 # or super classes. Setting the tag to NO turns the diagrams off. Note that 
 # this option also works with HAVE_DOT disabled, but it is recommended to 
 # install and use dot, since it yields more powerful graphs.

--- a/edslib/eds/45-seds_write_datatypedb_objects.lua
+++ b/edslib/eds/45-seds_write_datatypedb_objects.lua
@@ -415,7 +415,7 @@ collect_descisiontree_values = function (state, low, high)
     refidx = greatermark
   end
 
-  -- Add additional values less than than the current value, if any
+  -- Add additional values less than the current value, if any
   collect_descisiontree_values(state,low,median-1)
   if (refidx ~= #state.list) then
     lessmark = #state.list

--- a/edslib/fsw/CMakeLists.txt
+++ b/edslib/fsw/CMakeLists.txt
@@ -221,7 +221,7 @@ if(IS_CFS_MISSION_BUILD)
 
 endif(IS_CFS_MISSION_BUILD)
 
-# UT stubs should only be necesary on a CFS target build
+# UT stubs should only be necessary on a CFS target build
 if (ENABLE_UNIT_TESTS AND IS_CFS_ARCH_BUILD)
   add_subdirectory(ut-stubs)
 endif (ENABLE_UNIT_TESTS AND IS_CFS_ARCH_BUILD)

--- a/edslib/fsw/edsfsw.dox
+++ b/edslib/fsw/edsfsw.dox
@@ -196,7 +196,7 @@ EdsLib_MissionObject_t SAMPLE_EDS =
 
 The final application should be linked with `edslib_basic` and `SAMPLE_eds` libraries, which in turn depend on 
 all other component EDS libraries.  However, all "full" objects will be pruned by the linker because they will 
-not satisfy dependencies of this applicaiton.
+not satisfy dependencies of this application.
 
 
 \subsubsection dynamice Example dynamically linked C application

--- a/edslib/fsw/inc/edslib_datatypedb.h
+++ b/edslib/fsw/inc/edslib_datatypedb.h
@@ -73,7 +73,7 @@
 
 
 /**
- * Return codes for Edslib functions, packed into a int32_t type.
+ * Return codes for Edslib functions, packed into an int32_t type.
  *
  * In keeping with common paradigms, negative values are failures, zero
  * represents complete/normal success, other non-negative values can be
@@ -285,7 +285,7 @@ extern "C"
  * Initialize the EdsLib DataTypeDB internal state
  *
  * This should be called once during initialization by
- * programs wishing to use the the EDS DataTypeDB API calls.
+ * programs wishing to use the EDS DataTypeDB API calls.
  *
  * This function initializes all shared/global state information
  * internal to EdsLib.  In particular this will generate lookup

--- a/edslib/fsw/inc/edslib_displaydb.h
+++ b/edslib/fsw/inc/edslib_displaydb.h
@@ -94,7 +94,7 @@ extern "C"
  * Initialize the DisplayDB subsystem
  *
  * This should be called once during initialization by
- * programs wishing to use the the Display API calls.
+ * programs wishing to use the Display API calls.
  */
 void EdsLib_DisplayDB_Initialize(void);
 
@@ -291,7 +291,7 @@ void EdsLib_Generate_Hexdump(void *output, const uint8_t *DataPtr, uint16_t Disp
 /* **************************************************************************************
  * EDS BINARY <-> STRING CONVERTERS
  *
- * Thes functions convert between user-friendly string representations and the numeric
+ * These functions convert between user-friendly string representations and the numeric
  * representations of EDS identifiers and EDS-defined datatypes.
  * **************************************************************************************/
 

--- a/edslib/fsw/inc/edslib_id.h
+++ b/edslib/fsw/inc/edslib_id.h
@@ -68,7 +68,7 @@
 typedef uint32_t EdsLib_Id_t;
 
 /**
- * A EdsLib_MsgId value that is never valid.
+ * An EdsLib_MsgId value that is never valid.
  * Because the appid of 0 is reserved, a valid EdsLib_MsgId can
  * never be all zero.
  */
@@ -98,12 +98,12 @@ enum
 /***************************************************************************************
  * INITIALIZERS
  *
- * These macros may be used to statically initialize a EdsLib_MsgId value.  They are done
+ * These macros may be used to statically initialize an EdsLib_MsgId value.  They are done
  * as macros rather than inline functions to allow use in compile-time initializers.
  ***************************************************************************************/
 
 /**
- * Initialize a EdsLib_MsgId representing a generic non-message data structure.
+ * Initialize an EdsLib_MsgId representing a generic non-message data structure.
  * The CPU number will be set to 0 (default) and the format type will be set
  * to indicate a generic data structure.
  *

--- a/edslib/fsw/src/edslib_internal.h
+++ b/edslib/fsw/src/edslib_internal.h
@@ -200,7 +200,7 @@ typedef struct
 
 /**
  * Macro to set an iterator to the start of a given object
- * The object is specified directory as a EdsLib_DatabaseRef_t
+ * The object is specified directory as an EdsLib_DatabaseRef_t
  */
 #define EDSLIB_RESET_ITERATOR_FROM_REFOBJ(name,baseref)                 \
     do {                                                                \
@@ -210,7 +210,7 @@ typedef struct
 
 /**
  * Macro to set an iterator to the start of a given object
- * The object is specified directory as a EdsLib_Id_t
+ * The object is specified directory as an EdsLib_Id_t
  */
 #define EDSLIB_RESET_ITERATOR_FROM_EDSID(name,edsid)                            \
     do {                                                                        \

--- a/edslib/python/src/edslib_python_base.c
+++ b/edslib/python/src/edslib_python_base.c
@@ -154,7 +154,7 @@ PyObject *EdsLib_Python_ObjectBase_GenericNew(PyTypeObject *objtype, PyObject *k
     {
         /* sanity check -- this only constructs EDS object instance types */
         /* Note - A SubType is intended here, the base type is abstract,
-         * so to construct an object it should aways be a subtype */
+         * so to construct an object it should always be a subtype */
         if (!PyType_IsSubtype(objtype, &EdsLib_Python_ObjectBaseType))
         {
             PyErr_Format(PyExc_TypeError, "Cannot construct EDS objects of type %s\n",

--- a/edslib/python/src/edslib_python_buffer.c
+++ b/edslib/python/src/edslib_python_buffer.c
@@ -48,7 +48,7 @@ EdsLib_Binding_Buffer_Content_t* EdsLib_Python_Buffer_GetContentRef(EdsLib_Pytho
 {
     /*
      * Confirm writability
-     * Check if the user has requested writable flags on an non-writable buffer
+     * Check if the user has requested writable flags on a non-writable buffer
      */
     if ((userflags & PyBUF_WRITABLE) == PyBUF_WRITABLE && self->is_readonly)
     {

--- a/edslib/python/src/edslib_python_container.c
+++ b/edslib/python/src/edslib_python_container.c
@@ -167,7 +167,7 @@ static PyObject *EdsLib_Python_ObjectContainer_keys(PyObject *obj)
     /* sanity check that the db entry has a valid subentry list (it should for all containers) */
     if (dbent->SubEntityList == NULL || !PyList_Check(dbent->SubEntityList))
     {
-        return PyErr_Format(PyExc_TypeError, "%s is not an mappable EDS type", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(PyExc_TypeError, "%s is not a mappable EDS type", Py_TYPE(obj)->tp_name);
     }
 
     size = PyList_GET_SIZE(dbent->SubEntityList);
@@ -205,7 +205,7 @@ static PyObject *EdsLib_Python_ObjectContainer_values(PyObject *obj)
 
     if (dbent->SubEntityList == NULL || !PyList_Check(dbent->SubEntityList))
     {
-        return PyErr_Format(PyExc_TypeError, "%s is not an mappable EDS type", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(PyExc_TypeError, "%s is not a mappable EDS type", Py_TYPE(obj)->tp_name);
     }
 
     size = PyList_GET_SIZE(dbent->SubEntityList);
@@ -250,7 +250,7 @@ static PyObject *EdsLib_Python_ObjectContainer_items(PyObject *obj)
 
     if (dbent->SubEntityList == NULL || !PyList_Check(dbent->SubEntityList))
     {
-        return PyErr_Format(PyExc_TypeError, "%s is not an mappable EDS type", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(PyExc_TypeError, "%s is not a mappable EDS type", Py_TYPE(obj)->tp_name);
     }
 
     size = PyList_GET_SIZE(dbent->SubEntityList);
@@ -310,7 +310,7 @@ static PyObject *   EdsLib_Python_ObjectContainer_iter(PyObject *obj)
     /* sanity check that the db entry has a valid subentry list (it should for all containers) */
     if (dbent->SubEntityList == NULL || !PyList_Check(dbent->SubEntityList))
     {
-        return PyErr_Format(PyExc_TypeError, "%s is not an mappable EDS type", Py_TYPE(obj)->tp_name);
+        return PyErr_Format(PyExc_TypeError, "%s is not a mappable EDS type", Py_TYPE(obj)->tp_name);
     }
 
     result = PyObject_GC_New(EdsLib_Python_ContainerIterator_t, &EdsLib_Python_ContainerIteratorType);

--- a/edslib/python/src/edslib_python_databaseentry.c
+++ b/edslib/python/src/edslib_python_databaseentry.c
@@ -781,7 +781,7 @@ static PyObject * EdsLib_Python_DatabaseEntry_iter(PyObject *obj)
         /* sanity check that the db entry has a valid subentry list (it should for all containers) */
         if (dbent->SubEntityList == NULL || !PyList_Check(dbent->SubEntityList))
         {
-            return PyErr_Format(PyExc_TypeError, "%s is not an mappable EDS type", Py_TYPE(obj)->tp_name);
+            return PyErr_Format(PyExc_TypeError, "%s is not a mappable EDS type", Py_TYPE(obj)->tp_name);
         }
     	ContainerIter = PyObject_GC_New(EdsLib_Python_ContainerIterator_t, &EdsLib_Python_ContainerEntryIteratorType);
     	if (ContainerIter == NULL)

--- a/tool/scripts/05-seds_parse_defines.lua
+++ b/tool/scripts/05-seds_parse_defines.lua
@@ -29,7 +29,7 @@
 -- with the same keys as "xml_attrs" but placeholders resolved
 --
 -- NOTE: the semantics of this replacement is not specified by CCSDS book 876,
--- which specfies it as an implementation-defined substitution.
+-- which specifies it as an implementation-defined substitution.
 -- -------------------------------------------------------------------------
 
 SEDS.info "SEDS parse defines START"
@@ -128,7 +128,7 @@ for n in SEDS.root:iterate_subtree() do
   local attributes = {}
 
   -- The evaluate function is defined locally, such that
-  -- it can use the value of "n" as a context to evaulate references
+  -- it can use the value of "n" as a context to evaluate references
   SEDS.set_eval_func(function(v)
     return basic_define_evaluate(n, v)
   end)

--- a/tool/scripts/20-seds_resolve_sizes.lua
+++ b/tool/scripts/20-seds_resolve_sizes.lua
@@ -362,7 +362,7 @@ local function resolve_array_datatype_size(node)
   local member_size
 
   if (node.datatyperef.has_derivatives) then
-    -- containment relationsip: use maximum (buffer) size
+    -- containment relationship: use maximum (buffer) size
     member_size = node.datatyperef.max_size
   else
     -- basetype relationship, or simple containment: use basic resolved size
@@ -717,8 +717,8 @@ while (SEDS.get_error_count() == 0) do
   -- If the "unresolved" count ends up zero, then everything is satisfied - job done
   -- Otherwise, as long as the "resolved" count is non zero, then this indicates
   -- progress and the next pass may resolve more items.
-  -- The other possibilty, a resolved count of zero and a nonzero unresolved count,
-  -- constitutes an error.  Since no changes were made to the tree, subsquent passes
+  -- The other possibility, a resolved count of zero and a nonzero unresolved count,
+  -- constitutes an error.  Since no changes were made to the tree, subsequent passes
   -- will be no different.  The most likely cause of this would be a circular dependency.
 
   -- In this case, one more pass will be made, this time triggering an error message

--- a/tool/scripts/30-seds_resolve_components.lua
+++ b/tool/scripts/30-seds_resolve_components.lua
@@ -129,7 +129,7 @@ while (#pending_instance_list > 0 and SEDS.get_error_count() == 0) do
         provider_inst = SEDS.new_component_instance(provcomp, mapping.rule, instance.trigger or instance.component)
         pending_instance_list[1 + #pending_instance_list] = provider_inst
       else
-        -- For a other pattern (e.g. singleton), reuse the existing instance
+        -- For another pattern (e.g. singleton), reuse the existing instance
         provider_inst = mapping.rule.instance_list[1];
       end
       if (not provider_inst) then
@@ -166,7 +166,7 @@ while (#pending_instance_list > 0 and SEDS.get_error_count() == 0) do
     -- If there were no required interfaces, treat this as a "base" interface
     -- from which all communication is derived.  In the cFS world there should be
     -- only one of these and it should be the logical software bus.  This entertains
-    -- the possibilty that there is more than one of these such interfaces however
+    -- the possibility that there is more than one of these such interfaces however
     -- that is not really an expected mode of operation
     if (req_count == 0) then
       lowlevel_interfaces[1 + #lowlevel_interfaces] = instance

--- a/tool/src/seds_checksum.h
+++ b/tool/src/seds_checksum.h
@@ -71,7 +71,7 @@ void seds_checksum_init_table(void);
  *
  * @param sum previous checksum value
  * @param localvalue the integer value to incorporate into the checksum
- * @param signficant_bits the number of bits in localvalue to consider
+ * @param significant_bits the number of bits in localvalue to consider
  * @return updated checksum
  */
 seds_checksum_t seds_update_checksum_numeric(seds_checksum_t sum, uintmax_t localvalue, seds_integer_t significant_bits);

--- a/tool/src/seds_preprocess.c
+++ b/tool/src/seds_preprocess.c
@@ -45,7 +45,7 @@
 #include "seds_global.h"
 #include "seds_preprocess.h"
 
-static const char SEDS_PREPROCESS_ENVIORNMENT;
+static const char SEDS_PREPROCESS_ENVIRONMENT;
 
 /*******************************************************************************/
 /*                      Internal / static Helper Functions                     */
@@ -422,7 +422,7 @@ static int seds_resolve_load_references(lua_State *lua)
     lua_pushnil(lua);
     if (luaL_loadstring(lua, lua_tostring(lua, -2)) == LUA_OK)
     {
-        lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIORNMENT);
+        lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIRONMENT);
         lua_setfenv(lua, -2);
         lua_pushnil(lua);
     }
@@ -439,7 +439,7 @@ static int seds_resolve_load_references(lua_State *lua)
 
     lua_rawgeti(lua, LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS);
     defenv = lua_gettop(lua);
-    lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIORNMENT);
+    lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIRONMENT);
     lua_rawseti(lua, LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS);
 
     lua_pushnil(lua);
@@ -461,7 +461,7 @@ static int seds_resolve_load_references(lua_State *lua)
 static int seds_resolve_set_eval_func(lua_State *lua)
 {
     lua_settop(lua, 1);
-    lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIORNMENT);
+    lua_rawgetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIRONMENT);
     lua_insert(lua, 1);
     lua_setfield(lua, 1, "Evaluate");
     return 0;
@@ -489,5 +489,5 @@ void seds_preprocess_register_globals(lua_State *lua)
     lua_setfield(lua, 1, "set_eval_func");
 
     lua_newtable(lua);
-    lua_rawsetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIORNMENT);
+    lua_rawsetp(lua, LUA_REGISTRYINDEX, &SEDS_PREPROCESS_ENVIRONMENT);
 }

--- a/tool/src/seds_runtime.lua
+++ b/tool/src/seds_runtime.lua
@@ -49,7 +49,7 @@ local SEDS = {}
 --
 SEDS.to_safe_identifier = function (ident)
   -- Note that gsub actually returns two values.
-  -- The extra parethesis here only returns the first
+  -- The extra parentheses here only returns the first
   return (string.gsub(tostring(ident),"[^%w%d]+","_"))
 end
 

--- a/tool/src/seds_tree_node.h
+++ b/tool/src/seds_tree_node.h
@@ -52,7 +52,7 @@ typedef enum
      */
 
    SEDS_NODETYPE_UNKNOWN,                 /**< Reserved value - for nodes that are ignored */
-   SEDS_NODETYPE_ROOT,                    /**< Root node of entire heirarchy */
+   SEDS_NODETYPE_ROOT,                    /**< Root node of entire hierarchy */
    SEDS_NODETYPE_CCSDS_STANDARD_FIRST,    /**< Reserved index marker - not used */
 
    /* Basic EDS node types */

--- a/tool/src/seds_xmlparser.c
+++ b/tool/src/seds_xmlparser.c
@@ -410,7 +410,7 @@ static int seds_xmlparser_recreate_xml(lua_State *lua)
         lua_pushnil(lua);
 
         /*
-        * Note - lua_next pops 1 item from the stack, iterpreted as the prev table index, nil to start.
+        * Note - lua_next pops 1 item from the stack, interpreted as the prev table index, nil to start.
         * It then pushes 2 items back on - the next table index, and the corresponding value.
         * At the end of the table it pushes nothing back on, but still pops the last index.
         */
@@ -727,7 +727,7 @@ static void seds_xmlparser_endtag(void *data, const XML_Char *el)
 
     case SEDS_NODETYPE_PACKAGE:
         /*
-         * Namespaces needs special handing in case they have
+         * Namespaces needs special handling in case they have
          * implicitly nested namespaces within them.
          *
          */
@@ -1133,7 +1133,7 @@ int seds_xmlparser_create(lua_State *lua)
         /*
          * Attach a garbage collector function.
          * This way, when the above object goes out of scope,
-         * the file can be closed an the XML parser object can be freed.
+         * the file can be closed and the XML parser object can be freed.
          *
          * This method works even in error conditions where the normal exit path
          * is not followed (i.e. if someone called lua_error)


### PR DESCRIPTION
**Describe the contribution**
- Fixes #56
  - Updates parameter names in `CFE_MissionLib_Python_Interface_GetFromIntfName()` and `CFE_MissionLib_Python_Topic_GetFromTopicName()` implementations to match the prototypes
  - Fixes typo in `SEDS_PREPROCESS_ENVIORNMENT` const variable (environment is misspelled)
  - Fix up general comment typos along the way

**Testing performed**
None

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt