### PR TITLE
Fix #62, correct name match in table build

### DIFF
--- a/cfecfs/eds2cfetbl/eds2cfetbl.c
+++ b/cfecfs/eds2cfetbl/eds2cfetbl.c
@@ -179,8 +179,11 @@ void LoadTemplateFile(lua_State *lua, const char *Filename)
         EdsAppNameLen = strlen(EdsAppName);
         if (strncasecmp(EdsAppName, CFE_TBL_FileDefPtr->TableName, EdsAppNameLen) == 0)
         {
-            printf("Matched EDS Package Name: %s\n", EdsAppName);
-            break;
+            if (!isalpha((unsigned char)CFE_TBL_FileDefPtr->TableName[EdsAppNameLen]))
+            {
+                printf("Matched EDS Package Name: %s\n", EdsAppName);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**
Confirm that the next char in the name match is a separator before breaking out of the loop.  This avoids matching on a prefix, such as SC to SCH_LAB.

Fixes #62

**Testing performed**
Build tables for SC and SCH_LAB in same project/mission

**Expected behavior changes**
Successful table build

**System(s) tested on**
Debian

**Additional context**
This only fixes the issue for app names that share a substring but not a whole word/term.  For instance if using SCH and SCH_LAB together in the same mission, that will still be a problem.  But that is unlikely to occur.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.