### PR TITLE
Fix #61, add test error control types

### DIFF
--- a/edslib/fsw/inc/edslib_database_types.h
+++ b/edslib/fsw/inc/edslib_database_types.h
@@ -73,11 +73,13 @@ typedef double (*EdsLib_FloatingPointCalibratorFunc_t)(double x);
 typedef enum
 {
     EdsLib_ErrorControlType_INVALID = 0,
+    EdsLib_ErrorControlType_ALWAYS_ZERO,
     EdsLib_ErrorControlType_CHECKSUM,
     EdsLib_ErrorControlType_CHECKSUM_LONGITUDINAL,
     EdsLib_ErrorControlType_CRC8,
     EdsLib_ErrorControlType_CRC16_CCITT,
     EdsLib_ErrorControlType_CRC32,
+    EdsLib_ErrorControlType_CRC32C,
     EdsLib_ErrorControlType_MAX
 } EdsLib_ErrorControlType_t;
 

--- a/edslib/fsw/src/edslib_datatypedb_errorcontrol.c
+++ b/edslib/fsw/src/edslib_datatypedb_errorcontrol.c
@@ -69,11 +69,13 @@ static uintmax_t EdsLib_ErrorControlAlgorithm_CHECKSUM(const void *Base, uint32_
 static const EdsLib_ErrorControlImpl_t EDSLIB_ERRCTL_DISPATCH[EdsLib_ErrorControlType_MAX] =
 {
         [EdsLib_ErrorControlType_INVALID] = EdsLib_ErrorControlAlgorithm_ZERO,
+        [EdsLib_ErrorControlType_ALWAYS_ZERO] = EdsLib_ErrorControlAlgorithm_ZERO,
         [EdsLib_ErrorControlType_CHECKSUM] = EdsLib_ErrorControlAlgorithm_CHECKSUM,
         [EdsLib_ErrorControlType_CHECKSUM_LONGITUDINAL] = EdsLib_ErrorControlAlgorithm_CHECKSUM_LONGITUDINAL,
         [EdsLib_ErrorControlType_CRC8] = EdsLib_ErrorControlAlgorithm_CRC8,
         [EdsLib_ErrorControlType_CRC16_CCITT] = EdsLib_ErrorControlAlgorithm_CRC16_CCITT,
-        [EdsLib_ErrorControlType_CRC32] = EdsLib_ErrorControlAlgorithm_ZERO /* placeholder; not implemented yet */
+        [EdsLib_ErrorControlType_CRC32] = EdsLib_ErrorControlAlgorithm_ZERO, /* placeholder; not implemented yet */
+        [EdsLib_ErrorControlType_CRC32C] = EdsLib_ErrorControlAlgorithm_ZERO /* placeholder; not implemented yet */
 };
 
 


### PR DESCRIPTION
**Describe the contribution**
This adds schema extensions for ALWAYS_ZERO and CRC32C error control types.  This is mainly just to permit ingesting of XML files that reference these.  CRC32C is not actually implemented, it is mapped to the same function (always zero, for now).

Fixes #61

**Testing performed**
Ingest data sheets using these algorithms

**Expected behavior changes**
Successful ingest

**System(s) tested on**
Debian

**Additional context**
Actual implementation of the real CRC-32C is deferred for now, it just uses zero.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.