### PR TITLE
Fix #55, add support for AliasDataType element

### DIFF
--- a/edslib/eds/40-seds_write_headers.lua
+++ b/edslib/eds/40-seds_write_headers.lua
@@ -241,6 +241,13 @@ local function write_c_define(output,def)
   end
 end
 
+-- -------------------------------------------------
+-- Helper function to write an integer typedef
+-- -------------------------------------------------
+local function write_c_alias_typedef(output,node)
+  return { ctype = node.type:get_flattened_name() .. "_t" }
+end
+
 -- -----------------------------------------------------------------------------------------
 --                              Main output routine begins
 -- -----------------------------------------------------------------------------------------
@@ -248,6 +255,7 @@ end
 -- Handler table for various data type nodes
 local datatype_output_handler =
 {
+  ALIAS_DATATYPE = write_c_alias_typedef,
   INTEGER_DATATYPE = write_c_integer_typedef,
   CONTAINER_DATATYPE = write_c_struct_typedef,
   ARRAY_DATATYPE = write_c_array_typedef,

--- a/edslib/eds/45-seds_write_datatypedb_objects.lua
+++ b/edslib/eds/45-seds_write_datatypedb_objects.lua
@@ -788,6 +788,10 @@ local function write_c_container_detail_object(output,node)
 
 end
 
+local function write_c_alias_detail_object(output,node)
+  return { ["Detail.Alias"] = "{ .RefObj = " .. node.type.edslib_refobj_initializer .. " }" }
+end
+
 
 -- -----------------------------------------------------------------------
 -- Generate "BasicType" field value for master table
@@ -797,7 +801,10 @@ local function get_object_detail_fields(output,node)
   local typemap
   local detailfunc
 
-  if (node.resolved_size) then
+  if (node.entity_type == "ALIAS_DATATYPE") then
+    detailfunc = write_c_alias_detail_object
+    typemap = "ALIAS"
+  elseif (node.resolved_size) then
     if (node.resolved_size.bits > 0) then
       if (node.entity_type == "INTEGER_DATATYPE" or node.entity_type == "ENUMERATION_DATATYPE") then
         typemap = (node.is_signed and "SIGNED" or "UNSIGNED") .. "_INT"
@@ -891,7 +898,7 @@ for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
   for idx,dsobj in ipairs(datasheet_objs) do
     output:append_previous(",")
     output:start_group(string.format("{ /* %s */", refnames[idx] or "(none)"))
-    for _,key in ipairs({ "Checksum", "BasicType", "Flags", "NumSubElements", "SizeInfo", "Detail.Array", "Detail.Container", "Detail.Number", "Detail.String" }) do
+    for _,key in ipairs({ "Checksum", "BasicType", "Flags", "NumSubElements", "SizeInfo", "Detail.Alias", "Detail.Array", "Detail.Container", "Detail.Number", "Detail.String" }) do
       if (dsobj[key]) then
         output:append_previous(",")
         output:write(string.format(".%s = %s", key, dsobj[key]))

--- a/edslib/fsw/inc/edslib_api_types.h
+++ b/edslib/fsw/inc/edslib_api_types.h
@@ -98,6 +98,7 @@ typedef enum
     EDSLIB_BASICTYPE_CONTAINER,       /**< References to multiple other data blobs of heterogeneous types */
     EDSLIB_BASICTYPE_ARRAY,           /**< References to multiple other data blobs of homogeneous type */
     EDSLIB_BASICTYPE_COMPONENT,       /**< References to component entities */
+    EDSLIB_BASICTYPE_ALIAS,           /**< References to component entities */
     EDSLIB_BASICTYPE_MAX              /**< Reserved value, should always be last */
 } EdsLib_BasicType_t;
 

--- a/edslib/fsw/inc/edslib_database_types.h
+++ b/edslib/fsw/inc/edslib_database_types.h
@@ -247,6 +247,13 @@ struct EdsLib_StringDescriptor
 
 typedef struct EdsLib_StringDescriptor EdsLib_StringDescriptor_t;
 
+struct EdsLib_AliasDescriptor
+{
+    EdsLib_DatabaseRef_t RefObj;
+};
+
+typedef struct EdsLib_AliasDescriptor EdsLib_AliasDescriptor_t;
+
 union EdsLib_ObjectDetailDescriptor
 {
     const void *Ptr;
@@ -254,6 +261,7 @@ union EdsLib_ObjectDetailDescriptor
     const EdsLib_ArrayDescriptor_t *Array;
     const EdsLib_StringDescriptor_t String;
     const EdsLib_NumberDescriptor_t Number;
+    const EdsLib_AliasDescriptor_t  Alias;
 };
 
 typedef union EdsLib_ObjectDetailDescriptor EdsLib_ObjectDetailDescriptor_t;

--- a/edslib/fsw/src/edslib_datatypedb_lookup.c
+++ b/edslib/fsw/src/edslib_datatypedb_lookup.c
@@ -77,24 +77,41 @@ EdsLib_DataTypeDB_t EdsLib_DataTypeDB_GetTopLevel(const EdsLib_DatabaseObject_t 
 const EdsLib_DataTypeDB_Entry_t *EdsLib_DataTypeDB_GetEntry(const EdsLib_DatabaseObject_t *GD, const EdsLib_DatabaseRef_t *RefObj)
 {
     EdsLib_DataTypeDB_t Dict;
+    const EdsLib_DataTypeDB_Entry_t *DataDictEntry;
+    const EdsLib_DatabaseRef_t *CurrRef;
 
-    if (RefObj == NULL)
+    DataDictEntry = NULL;
+    CurrRef = RefObj;
+
+    while (true)
     {
-        return NULL;
+        if (CurrRef == NULL)
+        {
+            break;
+        }
+
+        Dict = EdsLib_DataTypeDB_GetTopLevel(GD, CurrRef->AppIndex);
+        if (Dict == NULL)
+        {
+            break;
+        }
+
+        if (CurrRef->TypeIndex >= Dict->DataTypeTableSize)
+        {
+            break;
+        }
+
+        DataDictEntry = &Dict->DataTypeTable[CurrRef->TypeIndex];
+
+        if (DataDictEntry->BasicType != EDSLIB_BASICTYPE_ALIAS)
+        {
+            break;
+        }
+
+        CurrRef = &DataDictEntry->Detail.Alias.RefObj;
     }
 
-    Dict = EdsLib_DataTypeDB_GetTopLevel(GD, RefObj->AppIndex);
-    if (Dict == NULL)
-    {
-        return NULL;
-    }
-
-    if (RefObj->TypeIndex >= Dict->DataTypeTableSize)
-    {
-        return NULL;
-    }
-
-    return &Dict->DataTypeTable[RefObj->TypeIndex];
+    return DataDictEntry;
 }
 
 

--- a/tool/scripts/10-seds_resolve_refs.lua
+++ b/tool/scripts/10-seds_resolve_refs.lua
@@ -261,6 +261,10 @@ local SEDS_ATTRIBUTE_TABLE =
   {
     datatyperef = { style="link", filter=SEDS.concrete_datatype_filter, required = true },
   },
+  ALIAS_DATATYPE =
+  {
+    type = { style="link", filter=SEDS.concrete_datatype_filter, required = true }
+  },
   DIMENSION =
   {
     indextyperef = { style="link", filter=SEDS.index_datatype_filter },

--- a/tool/scripts/20-seds_resolve_sizes.lua
+++ b/tool/scripts/20-seds_resolve_sizes.lua
@@ -577,6 +577,16 @@ local function resolve_subrange_datatype_size(node)
   return true
 end
 
+-- -------------------------------------------------------------------------
+-- Alias data type size resolver
+-- -------------------------------------------------------------------------
+local function resolve_alias_datatype_size(node)
+  if (not node.type.resolved_size) then
+    return node.type
+  end
+  node.resolved_size = SEDS.new_size_object(node.type.resolved_size)
+  return true
+end
 
 -- -----------------------------------------------------------------------------------------
 --                              Main object size resolution routine
@@ -584,6 +594,7 @@ end
 
 local SEDS_SIZE_RESOLVE_TABLE =
 {
+  ALIAS_DATATYPE = resolve_alias_datatype_size,
   CONTAINER_DATATYPE = resolve_container_datatype_size,
   ARRAY_DATATYPE = resolve_array_datatype_size,
   ENUMERATION_DATATYPE = resolve_enumeration_datatype_size,

--- a/tool/src/seds_runtime.lua
+++ b/tool/src/seds_runtime.lua
@@ -162,6 +162,15 @@ SEDS.create_nodetype_filter = function (want_nodetype)
   else
     node_filtertable[want_nodetype] = true
   end
+
+  -- If a datatype alias is encountered, then check the type it refers to
+  if (node_filtertable["ALIAS_DATATYPE"]) then
+    node_filtertable["ALIAS_DATATYPE"] = function(node)
+      local tgtype = node.type and node.type.entity_type or "UNKNOWN"
+      return node_filtertable[tgtype]
+    end
+  end
+
   return function (node)
     local result = node_filtertable[node.entity_type]
     while (type(result) == "function") do
@@ -237,6 +246,7 @@ SEDS.basenode_filter = SEDS.create_nodetype_filter
 -- A filter function that will match any concrete SEDS data type
 SEDS.concrete_datatype_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "CONTAINER_DATATYPE",
   "ARRAY_DATATYPE",
   "INTEGER_DATATYPE",
@@ -251,6 +261,7 @@ SEDS.concrete_datatype_filter = SEDS.create_nodetype_filter
 -- A filter function that will match any SEDS data type, including generics
 SEDS.any_datatype_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "CONTAINER_DATATYPE",
   "ARRAY_DATATYPE",
   "INTEGER_DATATYPE",
@@ -266,12 +277,14 @@ SEDS.any_datatype_filter = SEDS.create_nodetype_filter
 -- A filter function that will match only containers (for base types)
 SEDS.container_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "CONTAINER_DATATYPE"
 }
 
 -- A filter function that will match only datatypes which are suitable for indices
 SEDS.index_datatype_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "INTEGER_DATATYPE",
   "ENUMERATION_DATATYPE",
   "SUBRANGE_DATATYPE"
@@ -280,6 +293,7 @@ SEDS.index_datatype_filter = SEDS.create_nodetype_filter
 -- A filter function that will match any scalar SEDS data type
 SEDS.scalar_datatype_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "INTEGER_DATATYPE",
   "STRING_DATATYPE",
   "FLOAT_DATATYPE",
@@ -291,6 +305,7 @@ SEDS.scalar_datatype_filter = SEDS.create_nodetype_filter
 -- A filter function that will match only numeric data types
 SEDS.numeric_datatype_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "INTEGER_DATATYPE",
   "FLOAT_DATATYPE",
   "SUBRANGE_DATATYPE"
@@ -313,6 +328,7 @@ SEDS.referredintf_filter = SEDS.create_nodetype_filter
 -- A filter which matches anything that has named sub-entities
 SEDS.subentity_filter = SEDS.create_nodetype_filter
 {
+  "ALIAS_DATATYPE",
   "CONTAINER_DATATYPE",
   "DECLARED_INTERFACE",
   "REQUIRED_INTERFACE",

--- a/tool/src/seds_tree_methods.lua
+++ b/tool/src/seds_tree_methods.lua
@@ -154,6 +154,7 @@ local function get_qualified_name(node)
     CONTAINER_TRAILER_ENTRY_LIST = ".",
     CONTAINER_ENTRY_LIST = ".",
     CONTAINER_DATATYPE = "/",
+    ALIAS_DATATYPE = "/",
     ARRAY_DATATYPE = "/",
     INTEGER_DATATYPE = "/",
     FLOAT_DATATYPE = "/",

--- a/tool/src/seds_tree_node.c
+++ b/tool/src/seds_tree_node.c
@@ -107,6 +107,7 @@ static const char *SEDS_NODETYPE_LOOKUP[SEDS_NODETYPE_MAX] =
         [SEDS_NODETYPE_STRING_DATATYPE] = "STRING_DATATYPE",
         [SEDS_NODETYPE_BOOLEAN_DATATYPE] = "BOOLEAN_DATATYPE",
         [SEDS_NODETYPE_SUBRANGE_DATATYPE] = "SUBRANGE_DATATYPE",
+        [SEDS_NODETYPE_ALIAS_DATATYPE] = "ALIAS_DATATYPE",
         [SEDS_NODETYPE_SCALAR_DATATYPE_LAST] = "SCALAR_DATATYPE_LAST",
         [SEDS_NODETYPE_COMPOUND_DATATYPE_FIRST] = "COMPOUND_DATATYPE_FIRST",
         [SEDS_NODETYPE_ARRAY_DATATYPE] = "ARRAY_DATATYPE",
@@ -492,6 +493,9 @@ void seds_tree_node_register_globals(lua_State *lua)
     lua_pushinteger(lua, SEDS_USER_MESSAGE_WARNING);
     lua_pushcclosure(lua, seds_tree_mark_error, 1);
     lua_setfield(lua, -2, "warning");
+    lua_pushinteger(lua, SEDS_USER_MESSAGE_INFO);
+    lua_pushcclosure(lua, seds_tree_mark_error, 1);
+    lua_setfield(lua, -2, "info");
     lua_pushcfunction(lua, seds_generic_props_enumerate_properties);
     lua_setfield(lua, -2, "get_properties");
 

--- a/tool/src/seds_tree_node.h
+++ b/tool/src/seds_tree_node.h
@@ -122,6 +122,7 @@ typedef enum
 
    SEDS_NODETYPE_DYNAMIC_DATATYPE_FIRST,  /**< Reserved index marker - not used */
    SEDS_NODETYPE_GENERIC_TYPE,            /**< Generic Type (deferred definition) */
+   SEDS_NODETYPE_ALIAS_DATATYPE,          /**< Alias Data type */
    SEDS_NODETYPE_DYNAMIC_DATATYPE_LAST,   /**< Reserved index marker - not used */
 
    SEDS_NODETYPE_INTERFACE_FIRST,         /**< Reserved index marker - not used */

--- a/tool/src/seds_xmlparser.c
+++ b/tool/src/seds_xmlparser.c
@@ -90,6 +90,7 @@ static const seds_stringmap_t XML_SEDS_STARTTAG_MAP[] =
         /* Element types defined by SEDS and supported by this toolchain */
         { .tag_name = XML_CHAR_C("ActivitySet"),            .tag_id = SEDS_NODETYPE_ACTIVITY_SET },
         { .tag_name = XML_CHAR_C("Activity"),               .tag_id = SEDS_NODETYPE_ACTIVITY },
+        { .tag_name = XML_CHAR_C("AliasDataType"),          .tag_id = SEDS_NODETYPE_ALIAS_DATATYPE          },
         { .tag_name = XML_CHAR_C("AlternateSet"),           .tag_id = SEDS_NODETYPE_ALTERNATE_SET           },
         { .tag_name = XML_CHAR_C("Alternate"),              .tag_id = SEDS_NODETYPE_ALTERNATE               },
         { .tag_name = XML_CHAR_C("ANDedConditions"),        .tag_id = SEDS_NODETYPE_ANDED_CONDITIONS        },


### PR DESCRIPTION
**Describe the contribution**
This element creates an alias from one data type to another.

Fixes #55

**Testing performed**
Change ES MemOffset and MemAddress types to use alias, confirm working

**Expected behavior changes**
The `AliasDataType` XML element works

**System(s) tested on**
Debian

**Additional context**
Newly added to schema

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
