### PR TITLE
Fix #74, add table gen scripts

### DIFF
--- a/cfecfs/eds2cfetbl/CMakeLists.txt
+++ b/cfecfs/eds2cfetbl/CMakeLists.txt
@@ -38,3 +38,27 @@ target_link_libraries(eds2cfetbl
     cfe_edsdb_static
     dl
 )
+set_target_properties(eds2cfetbl PROPERTIES ENABLE_EXPORTS TRUE)
+
+# Export relevant information so the parent script can invoke the tool
+set(CFS_TABLETOOL_SCRIPT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts" CACHE INTERNAL "CFS table tool script directory")
+
+add_custom_target(tabletool-execute
+    COMMAND $(MAKE)
+        CC="${CMAKE_C_COMPILER}"
+        CFLAGS="${CMAKE_C_FLAGS}"
+        AR="${CMAKE_AR}"
+        TBLTOOL="$<TARGET_FILE:eds2cfetbl>"
+        cfetables
+    WORKING_DIRECTORY
+        "${MISSION_BINARY_DIR}/tables"
+    DEPENDS
+        mission-cfetables
+        eds2cfetbl
+)
+
+add_dependencies(mission-all tabletool-execute)
+add_dependencies(mission-install tabletool-execute)
+add_dependencies(mission-prebuild eds2cfetbl)
+
+install(DIRECTORY ${CMAKE_BINARY_DIR}/tables/staging/ DESTINATION .)

--- a/cfecfs/eds2cfetbl/scripts/add_cfe_tables_impl.cmake
+++ b/cfecfs/eds2cfetbl/scripts/add_cfe_tables_impl.cmake
@@ -1,0 +1,135 @@
+##################################################################
+#
+# FUNCTION: do_add_cfe_tables_impl
+#
+# Simplified routine to add CFS tables to be built with an app
+#
+# For apps with just a single table, the TABLE_FQNAME may be the
+# same as the app name, which is simple.
+#
+# For apps with multiple tables, the TABLE_FQNAME may be of the
+# form "${ADDTBL_ARG_APP_NAME}.${TABLE_NAME}" where ${ADDTBL_ARG_APP_NAME} refers to an
+# app target that was registered via the "add_cfe_app" function.
+#
+# Note that for backward compatibility, any name will be accepted
+# for TABLE_FQNAME.  However if this function cannot determine which
+# app the table is associated with, it will only have a default set
+# of INCLUDE_DIRECTORIES when building the C source file(s).  By
+# associating a table with an app using the conventions above, the
+# INCLUDE_DIRECTORIES from the parent app will be used when building the
+# tables.
+#
+# This function produces one or more library targets in CMake, using names
+# of the form: "tblobj_${ADDTBL_ARG_TARGET_NAME}_{TABLE_FQNAME}" where TGT reflects the name
+# of the target from targets.cmake and TABLE_FQNAME reflects the first
+# parameter to this function.
+#
+function(do_add_cfe_tables_impl TABLE_FQNAME)
+
+    cmake_parse_arguments(ADDTBL_ARG "" "APP_NAME;TARGET_NAME;INSTALL_SUBDIR" "" ${ARGN})
+
+    set(TEMPLATE_FILE   "${CFS_TABLETOOL_SCRIPT_DIR}/table_rule_template.d.in")
+    set(TABLE_GENSCRIPT "${CFS_TABLETOOL_SCRIPT_DIR}/generate_eds_table_rules.cmake")
+
+    set(TABLE_CMD_OPTS
+      -DTEMPLATE_FILE="${TEMPLATE_FILE}"
+      -DAPP_NAME="${ADDTBL_ARG_APP_NAME}"
+      -DTARGET_NAME="${ADDTBL_ARG_TARGET_NAME}"
+    )
+
+    if (ADDTBL_ARG_INSTALL_SUBDIR)
+      list(APPEND TABLE_CMD_OPTS
+        -DINSTALL_SUBDIR="${ADDTBL_ARG_INSTALL_SUBDIR}"
+      )
+    endif()
+
+    # If there is an ${ADDTBL_ARG_APP_NAME}.table target defined, make
+    # things depend on that.  Otherwise just depend on core_api.
+    set(TABLE_DEPENDENCIES core_api)
+    if (TARGET ${ADDTBL_ARG_APP_NAME}.table)
+        list(APPEND TABLE_DEPENDENCIES
+            ${ADDTBL_ARG_APP_NAME}.table
+        )
+        list(APPEND TABLE_CMD_OPTS
+            -DINCLUDE_DIRS="$<TARGET_PROPERTY:${ADDTBL_ARG_APP_NAME}.table,INTERFACE_INCLUDE_DIRECTORIES>"
+            -DCOMPILE_DEFS="$<TARGET_PROPERTY:${ADDTBL_ARG_APP_NAME}.table,INTERFACE_COMPILE_DEFINITIONS>"
+        )
+    else()
+        list(APPEND TABLE_CMD_OPTS
+            -DINCLUDE_DIRS="$<TARGET_PROPERTY:core_api,INTERFACE_INCLUDE_DIRECTORIES>"
+            -DCOMPILE_DEFS="$<TARGET_PROPERTY:core_api,INTERFACE_COMPILE_DEFINITIONS>"
+        )
+    endif()
+
+    # Note that the file list passed in are just a default - we now need
+    # to find the active source, which typically comes from the MISSION_DEFS dir.
+    # The TABLE_SELECTED_SRCS will become this list of active/selected source files
+    set(TABLE_SELECTED_SRCS)
+    foreach(TBL ${ADDTBL_ARG_UNPARSED_ARGUMENTS})
+
+        # The file source basename (without directory or ext) should be the same as the table
+        # binary filename with a ".tbl" extension (this is the convention assumed by elf2cfetbl)
+        get_filename_component(TABLE_SRC_NEEDED ${TBL} NAME)
+        get_filename_component(TABLE_BASENAME   ${TBL} NAME_WE)
+        set(TABLE_RULEFILE "${MISSION_BINARY_DIR}/tables/${ADDTBL_ARG_TARGET_NAME}_${TABLE_FQNAME}.${TABLE_BASENAME}.d")
+
+
+        # Check if an override exists at the mission level (recommended practice)
+        # This allows a mission to implement a customized table without modifying
+        # the original - this also makes for easier merging/updating if needed.
+        # Note this path list is in reverse-priority order, and only a single file
+        # will be end up being selected.
+        cfe_locate_implementation_file(TBL_SRC "${TABLE_SRC_NEEDED}"
+            OPTIONAL
+            FALLBACK_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${TBL}"
+            PREFIX "${ADDTBL_ARG_TARGET_NAME}"
+            SUBDIR tables
+        )
+
+        list(APPEND TABLE_SELECTED_SRCS ${TBL_SRC})
+
+        # Check if a Lua table gen script exists at the mission level
+        # This allows a mission to implement a customized table without modifying
+        # the original - this also makes for easier merging/updating if needed.
+        # For scripts multiple files can exist, they can all work together, the
+        # output is a list.
+        cfe_locate_implementation_file(TBL_LUA_LIST "${TABLE_BASENAME}.lua"
+            ALLOW_LIST OPTIONAL
+            PREFIX ${ADDTBL_ARG_TARGET_NAME}
+            SUBDIR tables
+        )
+        list(APPEND TBL_SRC ${TBL_LUA_LIST})
+
+        if (NOT TBL_SRC)
+            message(FATAL_ERROR "No table definition for ${APP_NAME}.${TABLE_BASENAME} on ${ADDTBL_ARG_TARGET_NAME} found")
+        endif()
+
+        # Note the table is not generated directly here, as it may require the native system compiler, so
+        # the call to the table tool (eds2cfetbl in this build) is deferred to the parent scope.  Instead, this
+        # generates a file that captures the state (include dirs, source files, targets) for use in a future step.
+        add_custom_command(
+            OUTPUT "${TABLE_RULEFILE}"
+            COMMAND ${CMAKE_COMMAND}
+                ${TABLE_CMD_OPTS}
+                -DOUTPUT_FILE="${TABLE_RULEFILE}"
+                -DTABLE_NAME="${TABLE_BASENAME}"
+                -DSOURCES="${TBL_SRC}"
+                -DOBJEXT="${CMAKE_C_OUTPUT_EXTENSION}"
+                -P "${TABLE_GENSCRIPT}"
+            WORKING_DIRECTORY
+                ${MISSION_BINARY_DIR}/tables
+            DEPENDS
+                ${TABLE_TEMPLATE}
+                ${TABLE_GENSCRIPT}
+                ${TABLE_DEPENDENCIES}
+          )
+
+          # Add a custom target to generate the config file
+          add_custom_target(generate_table_${ADDTBL_ARG_TARGET_NAME}_${ADDTBL_ARG_APP_NAME}_${TABLE_BASENAME}
+              DEPENDS "${TABLE_RULEFILE}"
+          )
+          add_dependencies(cfetables generate_table_${ADDTBL_ARG_TARGET_NAME}_${ADDTBL_ARG_APP_NAME}_${TABLE_BASENAME})
+
+    endforeach(TBL ${TBL_DEFAULT_SRC_FILES} ${ARGN})
+
+endfunction(do_add_cfe_tables_impl)

--- a/cfecfs/eds2cfetbl/scripts/eds2cfetbl_rules.mk
+++ b/cfecfs/eds2cfetbl/scripts/eds2cfetbl_rules.mk
@@ -1,0 +1,46 @@
+# Rules for EDS-based CFE table generation
+
+# the basic set of flags to pass to the table tool
+TBLTOOL_FLAGS += -e MISSION_DEFS=\"$(MISSION_DEFS)\"
+TBLTOOL_FLAGS += -e CPUNAME=\"$(CFE_TABLE_CPUNAME)\"
+TBLTOOL_FLAGS += -e APPNAME=\"$(CFE_TABLE_APPNAME)\"
+TBLTOOL_FLAGS += -e TABLENAME=\"$(CFE_TABLE_BASENAME)\"
+
+LOCAL_CFLAGS += $(addprefix -D,$(C_COMPILE_DEFS))
+LOCAL_CFLAGS += $(addprefix -I,$(C_INCLUDE_DIRS))
+LOCAL_CFLAGS += -DCFE_TABLE_NAME="$(CFE_TABLE_BASENAME)"
+
+AWK ?= /usr/bin/awk
+M4  ?= /usr/bin/m4
+
+.PRECIOUS: eds/%.c
+
+# This needs to strip comments from the original C file -
+# the best way to do that is to send it through the C preprocessor (-E switch)
+# NOTE: by defining CFE_TBL_FILEDEF_H here, we effectively squelch the normal CFE definition of the macro.
+# this way we can use our own macro definition instead, and actually evaluate it several different ways.
+eds/%.source:
+	@mkdir -pv $(dir $(@))
+	echo "$(<)" > "$(@)"
+
+eds/%.filedef: SRC=$(shell cat $(@:.filedef=.source))
+eds/%.filedef: eds/%.source $(TABLETOOL_SCRIPT_DIR)/extract_filedef.awk
+	$(CC) -E -MMD -MF "$(notdir $(@)).d" -MT "$(@)" -DCFE_TBL_FILEDEF_H $(CFLAGS) $(LOCAL_CFLAGS) -o "$(@).tmp" "$(SRC)"
+	$(AWK) -v SRC="$(SRC)" -f "$(TABLETOOL_SCRIPT_DIR)/extract_filedef.awk" "$(@).tmp" > "$(@).out"
+	mv "$(@).out" "$(@)"
+	rm -f "$(@).tmp"
+
+eds/%.objname: eds/%.filedef $(TABLETOOL_SCRIPT_DIR)/extract_varname.m4
+	$(M4) -P "$(TABLETOOL_SCRIPT_DIR)/extract_varname.m4" "$(<)" > "$(@)"
+
+eds/%.c: SRC=$(shell cat $(@:.c=.source))
+eds/%.c: OBJNAME=$(shell cat $(@:.c=.objname))
+eds/%.c: eds/%.objname $(TABLETOOL_SCRIPT_DIR)/extract_object.awk
+	$(AWK) -v SRC="$(SRC)" -v OBJNAME="$(OBJNAME)" -f "$(TABLETOOL_SCRIPT_DIR)/extract_object.awk" "$(SRC)" > "$(@).out"
+	mv "$(@).out" "$(@)"
+
+eds/%.o: eds/%.c $(TABLETOOL_SCRIPT_DIR)/eds_tbltool_filedef.h
+	$(CC) -Wall -Werror -fPIC -g $(CFLAGS) $(LOCAL_CFLAGS) -include "$(TABLETOOL_SCRIPT_DIR)/eds_tbltool_filedef.h" -o "$(@)" -c "$(<)"
+
+%.so: %.o
+	$(CC) $(CFLAGS) -shared -o $(@) $(<)

--- a/cfecfs/eds2cfetbl/scripts/eds_tbltool_filedef.h
+++ b/cfecfs/eds2cfetbl/scripts/eds_tbltool_filedef.h
@@ -1,0 +1,41 @@
+#ifndef EDS_TBLTOOL_FILEDEF_H
+#define EDS_TBLTOOL_FILEDEF_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <cfe_sb_eds_typedefs.h>
+
+CFE_SB_MsgIdValue_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
+CFE_SB_MsgIdValue_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
+
+uint16_t EdsTableTool_GetProcessorId(void);
+void EdsTableTool_DoExport(void *arg, const void *filedefptr, const void *obj, size_t sz);
+
+
+static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16_t TopicId)
+{
+    /* Instance number 0 is used for globals */
+    return CFE_SB_CmdTopicIdToMsgId(TopicId, 0);
+}
+
+static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16_t TopicId)
+{
+    /* Instance number 0 is used for globals */
+    return CFE_SB_TlmTopicIdToMsgId(TopicId, 0);
+}
+
+static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_LocalCmdTopicIdToMsgId(uint16_t TopicId)
+{
+    /* PSP-reported Instance number is used for locals */
+    return CFE_SB_CmdTopicIdToMsgId(TopicId, EdsTableTool_GetProcessorId());
+}
+
+static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16_t TopicId)
+{
+    /* PSP-reported Instance number is used for locals */
+    return CFE_SB_TlmTopicIdToMsgId(TopicId, EdsTableTool_GetProcessorId());
+}
+
+
+#endif

--- a/cfecfs/eds2cfetbl/scripts/extract_filedef.awk
+++ b/cfecfs/eds2cfetbl/scripts/extract_filedef.awk
@@ -1,0 +1,66 @@
+#!/usr/bin/awk -f
+
+BEGIN {
+    RS="\n";
+    ORS="\n";
+    FS=" ";
+    IS_FILEDEF_MACRO=0;   # set nonzero if the CFE_TBL_FILEDEF macro is found
+    IS_FILEDEF_DIRECT=0;  # set nonzero if the CFE_TBL_FileDef_t is instantiated directly (discouraged)
+    DIRECT_CONTENT="";
+}
+
+END {
+    if (IS_FILEDEF_MACRO >= 0) {
+        print "\nERROR: Unable to extract CFE_TBL_FILEDEF macro from: " SRC "\n" > "/dev/stderr"
+        exit 1
+    }
+}
+
+# The C preprocessor outputs lines starting with # that indicate which file it came from
+# We are only interested in content that was _directly_ in the table file here.
+/^#/ {
+    LINE=$2;
+    FILE=$3;
+    next;
+}
+
+# Ignore anything that is not in the original source file
+FILE!="\"" SRC "\"" {
+    next;
+}
+
+# Filedef starts at the CFE_TBL_FILEDEF macro
+IS_FILEDEF_MACRO==0 && /\<CFE_TBL_FILEDEF\>/ {
+    IS_FILEDEF_MACRO=1
+    IS_FILEDEF_DIRECT=-1
+}
+
+IS_FILEDEF_DIRECT==0 {
+    if ($1 == "CFE_TBL_FileDef_t") {
+        IS_FILEDEF_DIRECT=1
+        IS_FILEDEF_MACRO=-1
+    }
+}
+
+IS_FILEDEF_DIRECT==1 {
+    DIRECT_CONTENT=DIRECT_CONTENT $0
+    if ($0 ~ /;/) {
+        if (match(DIRECT_CONTENT, /{(.*)}/, OUT1) == 0) {
+            print "\nERROR: Unable to extract CFE_TBL_FILEDEF info from direct instatiation: " DIRECT "\n" > "/dev/stderr"
+            exit 1
+        }
+        # now that the CFE_TBL_FileDef_t content is identified, it first needs to be split at commas
+        split(OUT1[1], OUT2, ",")
+        # Then the first item taken out (only the first for now)
+        match(OUT2[1], /"(.*)"/, OUT3)
+        print "CFE_TBL_FILEDEF(" OUT3[1] ")"
+        IS_FILEDEF_DIRECT=-1
+    }
+}
+
+# send the "CFE_TBL_FILEDEF" macro content to the output
+IS_FILEDEF_MACRO==1 {
+    print
+    if ($0 ~ /\)/)
+        IS_FILEDEF_MACRO=-1
+}

--- a/cfecfs/eds2cfetbl/scripts/extract_object.awk
+++ b/cfecfs/eds2cfetbl/scripts/extract_object.awk
@@ -1,0 +1,54 @@
+#!/usr/bin/awk -f
+
+BEGIN {
+    IS_DECL=0
+}
+
+END {
+    if (DATATYPE) {
+        print "const char " OBJNAME "_EDS_TYPEDEF_NAME[] = \"" DATATYPE "\";\n"
+    }
+    else {
+        print "extract_object: Error: No instantiation of " OBJNAME " found in source file" > "/dev/stderr";
+        exit 1;
+    }
+
+    print "\n"
+    print "void " OBJNAME "_GENERATOR(void *arg)"
+    print "{\n"
+    print "#include \"" SRC  "\"\n"
+    print "EdsTableTool_DoExport(arg, &CFE_TBL_FileDef, &" OBJNAME ", sizeof(" OBJNAME "));"
+    print "}"
+}
+
+# This preserves the original "CFE_TBL_FILEDEF" info
+IS_DECL<0 {
+    print
+}
+
+IS_DECL==0 {
+    for (i=1; i < NF; i++) {
+        if (match($i, "^" OBJNAME "\\>" ) != 0) {
+            IS_DECL=i
+            break
+        }
+    }
+
+    if (IS_DECL) {
+        for (i=1; i < IS_DECL; i++) {
+            if ($i != "const") {
+                DATATYPE=$i
+            }
+        }
+        print DATATYPE
+        print $IS_DECL
+    }
+    else {
+        print $0
+    }
+}
+
+IS_DECL > 0 && /;/ {
+    IS_DECL=-1
+    print ";"
+}

--- a/cfecfs/eds2cfetbl/scripts/extract_varname.m4
+++ b/cfecfs/eds2cfetbl/scripts/extract_varname.m4
@@ -1,0 +1,1 @@
+m4_define(CFE_TBL_FILEDEF,$1)m4_dnl

--- a/cfecfs/eds2cfetbl/scripts/generate_eds_table_rules.cmake
+++ b/cfecfs/eds2cfetbl/scripts/generate_eds_table_rules.cmake
@@ -1,0 +1,52 @@
+##################################################################
+#
+# Sub-script to capture the table compile/generation environment
+#
+# This small script runs at build time (as opposed to prep time)
+# which captures a set of environment metadata
+#
+# It must be done this way such that generator expressions will
+# be evaluated now, during the arch build process, rather than
+# deferring the evaluation to the parent build where they may
+# have different values.
+#
+##################################################################
+
+set(STAGING_DIR staging ${TARGET_NAME} ${INSTALL_SUBDIR})
+string(REPLACE ";" "/" STAGING_DIR  "${STAGING_DIR}")
+
+# In case the INCLUDE_DIRS is a CMake list, convert to a space-separated list
+list(REMOVE_DUPLICATES INCLUDE_DIRS)
+string(REPLACE ";" " " INCLUDE_DIRS "${INCLUDE_DIRS}")
+
+list(REMOVE_DUPLICATES COMPILE_DEFS)
+string(REPLACE ";" " " COMPILE_DEFS "${COMPILE_DEFS}")
+
+set(TABLE_BINARY "${STAGING_DIR}/${TABLE_NAME}.tbl")
+set(TMP_DIR "eds/${TARGET_NAME}")
+set(TABLE_RULES)
+
+foreach(TBL_SRC ${SOURCES})
+
+    if (TBL_SRC MATCHES "\\.c$")
+        # Legacy C source files need a compile step before they can be used
+        set(TABLE_LEGACY_FILE "${TMP_DIR}/${APP_NAME}_${TABLE_NAME}")
+        string(APPEND TABLE_RULES
+            "${TABLE_LEGACY_FILE}.o: C_INCLUDE_DIRS += ${INCLUDE_DIRS}\n"
+            "${TABLE_LEGACY_FILE}.o: C_COMPILE_DEFS += ${COMPILE_DEFS}\n"
+            "${TABLE_LEGACY_FILE}.source: ${TBL_SRC}\n"
+            "\n")
+        set(DEP_FILE "${TABLE_LEGACY_FILE}.so")
+    else()
+        # Other source files (e.g. Lua) can be used directly by the tool
+        set(DEP_FILE "${TBL_SRC}")
+    endif()
+
+    string(APPEND TABLE_RULES
+        "${TABLE_BINARY}: ${DEP_FILE}\n"
+        "\n"
+    )
+
+endforeach()
+
+configure_file(${TEMPLATE_FILE} ${OUTPUT_FILE})

--- a/cfecfs/eds2cfetbl/scripts/table_rule_template.d.in
+++ b/cfecfs/eds2cfetbl/scripts/table_rule_template.d.in
@@ -1,0 +1,10 @@
+# Template for table configuration
+
+cfetables: ${TABLE_BINARY}
+
+${TABLE_BINARY}: CFE_TABLE_CPUNAME   := ${TARGET_NAME}
+${TABLE_BINARY}: CFE_TABLE_APPNAME   := ${APP_NAME}
+${TABLE_BINARY}: CFE_TABLE_BASENAME  := ${TABLE_NAME}
+
+# Rules to build ${TABLE_BINARY}
+${TABLE_RULES}

--- a/cfecfs/eds2cfetbl/scripts/tabletool_rule.mk
+++ b/cfecfs/eds2cfetbl/scripts/tabletool_rule.mk
@@ -1,0 +1,18 @@
+# Makefile for EDS-based CFE table generation
+
+C_INCLUDE_DIRS += $(MISSION_BINARY_DIR)/inc
+
+.PHONY: cfetables
+
+cfetables:
+	@echo "Table build completed"
+
+# The dependency of this rule should always be a relative path starting with elf/,
+# at least with the current rule generator script, so it matches the elf/% pattern rule.
+# But because elf2cfetbl only writes its output to the current working dir, it has to be run
+# after changing dirs into the staging area.  Thus the path to the elf file needs to be adjusted.
+# Ideally this chould be done with the $(abspath f...) function but this doesn't exist in older versions.
+# As a workaround, $CURDIR is used.
+staging/%.tbl:
+	@mkdir -pv "$(dir $(@))"
+	cd "$(dir $(@))" && $(TBLTOOL) $(TBLTOOL_FLAGS) "$(CURDIR)/$(<)"


### PR DESCRIPTION
**Describe the contribution**
Includes the complete set of CMake logic + supporting scripts and makefiles to build tables in an EDS environment.

Also improves eds2cfetbl to better handle the existing "C" source files.

Fixes #74

**Testing performed**
Build and run all tests

**Expected behavior changes**
Original CFE tables from apps like CF, HS, and SC should be usable without modification

**System(s) tested on**
Debian

**Additional context**
This does depend on the apps using the CFE_TBL_FILEDEF macro properly, as it picks specific items out of this struct.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
