### PR TITLE
Fix #79, Correct MsgId check

### DIFF
--- a/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
@@ -34,14 +34,6 @@
 #define CFE_MSG_SHDR_TYPE_TLM_BIT     (CCSDS_SecHdrFlags_BareTlm & CCSDS_SecHdrFlags_Tlm)
 #define CFE_MSG_SHDR_TYPE_CMD_BIT     (CCSDS_SecHdrFlags_BareCmd & CCSDS_SecHdrFlags_Cmd)
 
-#ifdef jphfix
-CFE_MSG_Message_t *CFE_MSG_ConvertPtr(CFE_MSG_BaseMsg_t *BaseMsg)
-{
-    void *Msg = BaseMsg;
-    return Msg;
-}
-#endif
-
 /*----------------------------------------------------------------
  *
  * Function: CFE_MSG_GetHeaderVersion

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
@@ -96,7 +96,7 @@ CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
      * not really a concept of a "highest" msg ID at all.  However, for historical/backward
      * compatibility reasons, this symbol is still defined in SB.
      */
-    if (MsgPtr == NULL || CFE_SB_MsgIdToValue(MsgId) > CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)
+    if (MsgPtr == NULL || !CFE_SB_IsValidMsgId(MsgId))
     {
         return CFE_MSG_BAD_ARGUMENT;
     }


### PR DESCRIPTION
**Describe the contribution**
Use the "CFE_SB_IsValidMsgId()" function to check msgids, as this is the source of truth.

Fixes #79

**Testing performed**
Build and run CFE, run functional test

**Expected behavior changes**
EDS msg implementation now uses consistent MsgId check

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
