### PR TITLE
Fix #83, allow the EDS MsgIDs to fully match baseline build

### DIFF
--- a/cfecfs/missionlib/arch_build.cmake
+++ b/cfecfs/missionlib/arch_build.cmake
@@ -15,7 +15,7 @@
 
 add_custom_target(edstool-execute
     COMMAND "\$(MAKE)"
-        -I ${CMAKE_BINARY_DIR}/obj
+        ARCH_BINARY_DIR=${CMAKE_BINARY_DIR}
         -f ${missionlib_MISSION_DIR}/cmake/edstool-execute-arch.mk
         all
     WORKING_DIRECTORY

--- a/cfecfs/missionlib/cmake/edstool-execute-arch.mk
+++ b/cfecfs/missionlib/cmake/edstool-execute-arch.mk
@@ -1,4 +1,11 @@
-include edstool-buildenv.d
+# NOTE: This relies on ARCH_BINARY_DIR being passed in via command line
+# Specifically the edstool-buildenv.d file must be present in this dir, and
+# this specifies values for OBJDIR, BUILD_CONFIG, CC/AR/LD, and others.
+include $(wildcard $(ARCH_BINARY_DIR)/obj/*.d)
+
+ifeq ($(OBJDIR),)
+$(error OBJDIR is not set, confirm that edstool-buildenv.d exists under $(ARCH_BINARY_DIR)/obj)
+endif
 
 # The O variable in this context is localized; should not use O from the parent here.
 O := $(OBJDIR)

--- a/cfecfs/missionlib/eds/80-build_cfe_sb_interfacedb.lua
+++ b/cfecfs/missionlib/eds/80-build_cfe_sb_interfacedb.lua
@@ -40,7 +40,7 @@ end
 -- This is currently only one file, the "interfacedb_impl"
 -- ------------------------------------------------
 local output = SEDS.output_open(makefilename)
-output:write("include edstool-buildenv.d $(wildcard $(O)/*.d)")
+output:write("include $(O)/edstool-buildenv.d $(wildcard $(O)/*.d)")
 output:write("include $(EDSLIB_SOURCE_DIR)/cmake/dbobj_patternrules.mk")
 output:add_whitespace(1)
 output:write("# Interface DB Object")

--- a/edslib/eds/40-seds_write_headers.lua
+++ b/edslib/eds/40-seds_write_headers.lua
@@ -473,7 +473,6 @@ for dp in SEDS.root:iterate_subtree("DESIGN_PARAMETERS") do
 end
 
 for _,pkgname in ipairs(all_designparam_files) do
-  if (#all_designparam_defines[pkgname] > 0) then
     local dpfile = SEDS.to_filename("designparameters.h", pkgname)
     output = SEDS.output_open(dpfile)
     output:section_marker("Design Parameters")
@@ -481,7 +480,6 @@ for _,pkgname in ipairs(all_designparam_files) do
       write_c_define(output, def)
     end
     SEDS.output_close(output)
-  end
 end
 
 -- The final "designparameters.h" file simply summarizes all existing files

--- a/edslib/eds/55-write_edsdb_makefiles.lua
+++ b/edslib/eds/55-write_edsdb_makefiles.lua
@@ -89,7 +89,7 @@ SEDS.output_close(output)
 -- --------------------------------------------------------------------
 output = SEDS.output_open(makefilename)
 
-output:write("include edstool-buildenv.d $(wildcard $(O)/*.d)")
+output:write("include $(O)/edstool-buildenv.d $(wildcard $(O)/*.d)")
 output:write("include $(EDSLIB_SOURCE_DIR)/cmake/dbobj_patternrules.mk")
 output:add_whitespace(1)
 

--- a/edslib/fsw/CMakeLists.txt
+++ b/edslib/fsw/CMakeLists.txt
@@ -58,7 +58,7 @@
 #  This CMake recipe simply exposes the 2 library targets separately
 #  and it is up to the CFE build to decide which one to link to.  This
 #  determines which sets of EDS functions are available to cFS applications.
-#  (The external variable CFE_SYSTEM_EDSDB_DYNAMIC_LINK affects this)
+#  (The external variable CFE_EDS_LINK_MODE affects this)
 #
 #
 # 2) Shared library target: "edslib"

--- a/tool/src/seds_outputfile.c
+++ b/tool/src/seds_outputfile.c
@@ -1002,7 +1002,7 @@ static int seds_lua_output_file_mkdir(lua_State *lua)
 {
     const char *dirname = luaL_checkstring(lua, 1);
 
-    if (mkdir(dirname, 0775) != 0)
+    if (mkdir(dirname, 0775) != 0 && errno != EEXIST)
     {
         return luaL_error(lua, "mkdir(): %s", strerror(errno));
     }


### PR DESCRIPTION
**Describe the contribution**
Update the MsgID mapping logic such that it can exactly reproduce the MsgID values used in the baseline / non-EDS build.

This allows one to switch back and forth between an EDS and non-EDS workflow without disrupting MsgID values.

Fixes #83

**Testing performed**
Build and run all tests

**Expected behavior changes**
MsgIDs can be preserved between EDS and non-EDS builds

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
