### PR TITLE
Fix #85, updates to struct/typedef names

### DIFF
--- a/cfecfs/eds2cfetbl/eds2cfetbl.c
+++ b/cfecfs/eds2cfetbl/eds2cfetbl.c
@@ -60,9 +60,9 @@
 #include "cfe_tbl_filedef.h"
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_mission_eds_interface_parameters.h"
-#include "cfe_tbl_eds_typedefs.h"
-#include "cfe_fs_eds_typedefs.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "cfe_tbl_eds_datatypes.h"
+#include "cfe_fs_eds_datatypes.h"
+#include "cfe_sb_eds_datatypes.h"
 #include "edslib_lua_objects.h"
 #include "cfe_missionlib_lua_softwarebus.h"
 #include "cfe_missionlib_runtime.h"
@@ -88,10 +88,10 @@ EdsTableTool_Global_t EdsTableTool_Global;
  * This calls the same impl that CFE FSW uses
  *
  *-----------------------------------------------------------------*/
-CFE_SB_MsgIdValue_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum)
+EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum)
 {
-    const CFE_SB_Listener_Component_t  Params = {{ .InstanceNumber = InstanceNum, .TopicId = TopicId }};
-    CFE_SB_SoftwareBus_PubSub_Interface_t Output;
+    const EdsComponent_CFE_SB_Listener_t  Params = {{ .InstanceNumber = InstanceNum, .TopicId = TopicId }};
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t Output;
 
     CFE_MissionLib_MapListenerComponent(&Output, &Params);
 
@@ -104,10 +104,10 @@ CFE_SB_MsgIdValue_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t Ins
  * This calls the same impl that CFE FSW uses
  *
  *-----------------------------------------------------------------*/
-CFE_SB_MsgIdValue_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum)
+EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_TlmTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum)
 {
-    const CFE_SB_Publisher_Component_t  Params = {{ .InstanceNumber = InstanceNum, .TopicId = TopicId }};
-    CFE_SB_SoftwareBus_PubSub_Interface_t Output;
+    const EdsComponent_CFE_SB_Publisher_t  Params = {{ .InstanceNumber = InstanceNum, .TopicId = TopicId }};
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t Output;
 
     CFE_MissionLib_MapPublisherComponent(&Output, &Params);
 
@@ -182,8 +182,8 @@ void LoadTemplateFile(lua_State *lua, const char *Filename)
     int obj_idx;
     size_t RuntimeAppNameLen;
     CFE_TBL_FileDef_t *CFE_TBL_FileDefPtr;
-    BASE_TYPES_ApiName_String_t RuntimeAppName;
-    BASE_TYPES_ApiName_String_t TableName;
+    EdsDataType_BASE_TYPES_ApiName_t RuntimeAppName;
+    EdsDataType_BASE_TYPES_ApiName_t TableName;
     const char *EdsAppName;
     size_t EdsAppNameLen;
     char EdsTypeName[64];
@@ -551,11 +551,11 @@ int Write_CFE_EnacapsulationFile(lua_State *lua)
 {
     union
     {
-        CFE_FS_Header_t FileHeader;
-        CFE_TBL_File_Hdr_t TblHeader;
+        EdsDataType_CFE_FS_Header_t FileHeader;
+        EdsDataType_CFE_TBL_File_Hdr_t TblHeader;
     } Buffer;
-    CFE_FS_Header_PackedBuffer_t PackedFileHeader;
-    CFE_TBL_File_Hdr_PackedBuffer_t PackedTblHeader;
+    EdsPackedBuffer_CFE_FS_Header_t PackedFileHeader;
+    EdsPackedBuffer_CFE_TBL_File_Hdr_t PackedTblHeader;
     uint32_t TblHeaderBlockSize;
     uint32_t FileHeaderBlockSize;
     EdsLib_Id_t PackedEdsId;

--- a/cfecfs/eds2cfetbl/scripts/eds_tbltool_filedef.h
+++ b/cfecfs/eds2cfetbl/scripts/eds_tbltool_filedef.h
@@ -4,34 +4,34 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <cfe_sb_eds_typedefs.h>
+#include <cfe_sb_eds_datatypes.h>
 
-CFE_SB_MsgIdValue_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
-CFE_SB_MsgIdValue_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
+EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_CmdTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
+EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_TlmTopicIdToMsgId(uint16_t TopicId, uint16_t InstanceNum);
 
 uint16_t EdsTableTool_GetProcessorId(void);
 void EdsTableTool_DoExport(void *arg, const void *filedefptr, const void *obj, size_t sz);
 
 
-static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16_t TopicId)
+static inline EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16_t TopicId)
 {
     /* Instance number 0 is used for globals */
     return CFE_SB_CmdTopicIdToMsgId(TopicId, 0);
 }
 
-static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16_t TopicId)
+static inline EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16_t TopicId)
 {
     /* Instance number 0 is used for globals */
     return CFE_SB_TlmTopicIdToMsgId(TopicId, 0);
 }
 
-static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_LocalCmdTopicIdToMsgId(uint16_t TopicId)
+static inline EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_LocalCmdTopicIdToMsgId(uint16_t TopicId)
 {
     /* PSP-reported Instance number is used for locals */
     return CFE_SB_CmdTopicIdToMsgId(TopicId, EdsTableTool_GetProcessorId());
 }
 
-static inline CFE_SB_MsgIdValue_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16_t TopicId)
+static inline EdsDataType_CFE_SB_MsgIdValue_t CFE_SB_LocalTlmTopicIdToMsgId(uint16_t TopicId)
 {
     /* PSP-reported Instance number is used for locals */
     return CFE_SB_TlmTopicIdToMsgId(TopicId, EdsTableTool_GetProcessorId());

--- a/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
+++ b/cfecfs/edsmsg/fsw/inc/cfe_msg_hdr_eds.h
@@ -172,19 +172,4 @@ struct CFE_MSG_TelemetryHeader
     union CFE_EDSMSG_TelemetryHeader_Aligned Content;
 };
 
-#ifdef jphfix
-/**
- * Helper function to cast an arbitrary base pointer to a CFE_MSG_Message_t* for use with SB APIs
- */
-static inline CFE_MSG_Message_t *CFE_MSG_CastBaseMsg(void *BaseMsg)
-{
-    /*
-     * In a pedantic sense, this is "promoting" the base message pointer to the
-     * union type.  This should not be an actual violation though, as the union
-     * contains a CFE_MSG_Message_t member.
-     */
-    return ((CFE_MSG_Message_t *)BaseMsg);
-}
-#endif
-
 #endif /* CFE_MSG_HDR_EDS_H */

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_commonhdr.c
@@ -24,10 +24,12 @@
 #include "cfe_msg.h"
 #include "cfe_error.h"
 
-#include "ccsds_spacepacket_eds_typedefs.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "cfe_sb_eds_datatypes.h"
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_missionlib_runtime.h"
+
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
 
 #define CFE_MSG_SHDR_PRESENT_MASK_BIT (CCSDS_SecHdrFlags_Tlm & CCSDS_SecHdrFlags_Cmd)
 #define CFE_MSG_SHDR_TYPE_MASK_BIT    (CCSDS_SecHdrFlags_Tlm ^ CCSDS_SecHdrFlags_Cmd)
@@ -44,14 +46,14 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || Version == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     *Version = Hdr->VersionId;
 
@@ -68,14 +70,14 @@ CFE_Status_t CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_H
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t Version)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || Version > 7)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     Hdr->VersionId = Version;
 
@@ -92,14 +94,14 @@ CFE_Status_t CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderV
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || Type == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     switch (Hdr->SecHdrFlags)
     {
@@ -129,15 +131,15 @@ CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Ty
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
 {
-    CCSDS_CommonHdr_t *      Hdr;
-    CCSDS_SecHdrFlags_Enum_t SetVal;
+    EdsDataType_CCSDS_CommonHdr_t * Hdr;
+    EdsDataType_CCSDS_SecHdrFlags_t SetVal;
 
     if (MsgPtr == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr    = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr    = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
     SetVal = 0;
 
     if (Type == CFE_MSG_Type_Tlm)
@@ -169,14 +171,14 @@ CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || HasSecondary == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     *HasSecondary = (Hdr->SecHdrFlags & CFE_MSG_SHDR_PRESENT_MASK_BIT) != 0;
 
@@ -193,15 +195,15 @@ CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary)
 {
-    CCSDS_CommonHdr_t *      Hdr;
-    CCSDS_SecHdrFlags_Enum_t SetVal;
+    EdsDataType_CCSDS_SecHdrFlags_t SetVal;
+    EdsDataType_CCSDS_CommonHdr_t * Hdr;
 
     if (MsgPtr == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     if (HasSecondary)
     {
@@ -228,14 +230,14 @@ CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSe
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || ApId == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     *ApId = Hdr->AppId;
 
@@ -252,14 +254,14 @@ CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *Ap
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || ApId > 0x3FF)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     Hdr->AppId = ApId;
 
@@ -276,14 +278,14 @@ CFE_Status_t CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || SegFlag == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* JPHFIX: should be EDS enum? */
     switch (Hdr->SeqFlag)
@@ -318,14 +320,14 @@ CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MS
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t SegFlag)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* JPHFIX: should be EDS enum? */
     switch (SegFlag)
@@ -359,14 +361,14 @@ CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segm
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || SeqCnt == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     *SeqCnt = Hdr->Sequence;
 
@@ -383,14 +385,14 @@ CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_S
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || SeqCnt > 0x3FFF)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     Hdr->Sequence = SeqCnt;
 
@@ -420,14 +422,14 @@ CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t Seq
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
 {
-    const CCSDS_CommonHdr_t *Hdr;
+    const EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     if (MsgPtr == NULL || Size == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* note that EDS pack/unpack reapplies the CCSDS length calibration */
     *Size = Hdr->Length + 7;
@@ -445,7 +447,7 @@ CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Si
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size)
 {
-    CCSDS_CommonHdr_t *Hdr;
+    EdsDataType_CCSDS_CommonHdr_t *Hdr;
 
     /*
      * note that EDS pack/unpack reapplies the traditional CCSDS length calibration (+/- 7)
@@ -457,7 +459,7 @@ CFE_Status_t CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size)
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    Hdr = (CCSDS_CommonHdr_t *)MsgPtr;
+    Hdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     Hdr->Length = Size - 7;
 

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_dispatcher.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_dispatcher.c
@@ -39,16 +39,16 @@
 CFE_Status_t CFE_MSG_EdsDispatch(uint16 InterfaceID, uint16 IndicationIndex, uint16 DispatchTableID,
                                  const CFE_SB_Buffer_t *Buffer, const void *DispatchTable)
 {
-    const EdsLib_DatabaseObject_t *       GD;
-    CFE_MissionLib_TopicInfo_t            TopicInfo;
-    CFE_MissionLib_IndicationInfo_t       IndicationInfo;
-    EdsLib_DataTypeDB_TypeInfo_t          TypeInfo;
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSubParams;
-    EdsLib_Id_t                           ArgumentType;
-    int32_t                               Status;
-    uint16_t                              TopicId;
-    uint16_t                              DispatchOffset;
-    CFE_MSG_Size_t                        BufferSize;
+    const EdsLib_DatabaseObject_t *          GD;
+    CFE_MissionLib_TopicInfo_t               TopicInfo;
+    CFE_MissionLib_IndicationInfo_t          IndicationInfo;
+    EdsLib_DataTypeDB_TypeInfo_t             TypeInfo;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSubParams;
+    EdsLib_Id_t                              ArgumentType;
+    int32_t                                  Status;
+    uint16_t                                 TopicId;
+    uint16_t                                 DispatchOffset;
+    CFE_MSG_Size_t                           BufferSize;
     union
     {
         cpuaddr     MemAddr;
@@ -66,16 +66,16 @@ CFE_Status_t CFE_MSG_EdsDispatch(uint16 InterfaceID, uint16 IndicationIndex, uin
 
     switch (InterfaceID)
     {
-        case CFE_SB_Telemetry_Interface_ID:
+        case EDS_INTERFACE_ID(CFE_SB_Telemetry):
         {
-            CFE_SB_Publisher_Component_t PublisherParams;
+            EdsComponent_CFE_SB_Publisher_t PublisherParams;
             CFE_MissionLib_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
             TopicId = PublisherParams.Telemetry.TopicId;
             break;
         }
-        case CFE_SB_Telecommand_Interface_ID:
+        case EDS_INTERFACE_ID(CFE_SB_Telecommand):
         {
-            CFE_SB_Listener_Component_t ListenerParams;
+            EdsComponent_CFE_SB_Listener_t ListenerParams;
             CFE_MissionLib_UnmapListenerComponent(&ListenerParams, &PubSubParams);
             TopicId = ListenerParams.Telecommand.TopicId;
             break;
@@ -120,7 +120,7 @@ CFE_Status_t CFE_MSG_EdsDispatch(uint16 InterfaceID, uint16 IndicationIndex, uin
          * The actual type of the argument must be determined to figure out which one to invoke. */
         EdsLib_DataTypeDB_DerivativeObjectInfo_t DerivObjInfo;
 
-        Status = EdsLib_DataTypeDB_IdentifyBuffer(GD, ArgumentType, Buffer->Msg.Byte, &DerivObjInfo);
+        Status = EdsLib_DataTypeDB_IdentifyBuffer(GD, ArgumentType, Buffer, &DerivObjInfo);
         if (Status != EDSLIB_SUCCESS)
         {
             return CFE_STATUS_UNKNOWN_MSG_ID;

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_init.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_init.c
@@ -28,6 +28,9 @@
 #include "cfe_time.h"
 #include "cfe_missionlib_runtime.h"
 
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
+
 /*----------------------------------------------------------------
  *
  * Function: CFE_MSG_Init
@@ -38,10 +41,10 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
-    CCSDS_CommonHdr_t *CommonHdr;
-    CFE_Status_t       Status;
+    EdsDataType_CCSDS_CommonHdr_t *CommonHdr;
+    CFE_Status_t                   Status;
 
-    if (MsgPtr == NULL || Size < sizeof(CCSDS_CommonHdr_t))
+    if (MsgPtr == NULL || Size < sizeof(EdsDataType_CCSDS_CommonHdr_t))
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
@@ -53,7 +56,7 @@ CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_M
     Status = CFE_MSG_SetMsgId(MsgPtr, MsgId);
     if (Status == CFE_SUCCESS)
     {
-        CommonHdr = (CCSDS_CommonHdr_t *)MsgPtr;
+        CommonHdr = (EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
         /* Default to complete packets */
         CommonHdr->SeqFlag = 3; /* jphfix: enum? */

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_msgid.c
@@ -26,8 +26,8 @@
 #include "cfe_sb.h"
 #include "cfe_error.h"
 
-#include "ccsds_spacepacket_eds_typedefs.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_sb_eds_datatypes.h"
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_missionlib_runtime.h"
 
@@ -41,8 +41,8 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 {
-    CFE_Status_t                          Status;
-    CFE_SB_SoftwareBus_PubSub_Interface_t Params;
+    CFE_Status_t                             Status;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t Params;
 
     if (Type == NULL)
     {
@@ -73,7 +73,7 @@ CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type
 
 CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
 {
-    CFE_SB_SoftwareBus_PubSub_Interface_t Params;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t Params;
 
     if (MsgPtr == NULL || MsgId == NULL)
     {
@@ -89,7 +89,7 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
 
 CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
 {
-    CFE_SB_SoftwareBus_PubSub_Interface_t Params;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t Params;
 
     /*
      * NOTE: in reality the EDS may map any bits of the MsgId to the message, there is

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_cmd.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_cmd.c
@@ -23,6 +23,9 @@
  */
 #include "cfe_msg.h"
 
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
+
 /*----------------------------------------------------------------
  *
  * Function: CFE_MSG_GetFcnCode
@@ -33,15 +36,15 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode)
 {
-    const CFE_HDR_CommandHeader_t *CmdPtr;
-    const CCSDS_CommonHdr_t *      CommonHdr;
+    const EdsDataType_CFE_HDR_CommandHeader_t *CmdPtr;
+    const EdsDataType_CCSDS_CommonHdr_t *      CommonHdr;
 
     if (MsgPtr == NULL || FcnCode == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    CommonHdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    CommonHdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* This confirms if it is OK to access the pointer as a "CommandHeader" type */
     if (CommonHdr->SecHdrFlags != CCSDS_SecHdrFlags_Cmd)
@@ -49,7 +52,7 @@ CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode
         return CFE_MSG_WRONG_MSG_TYPE;
     }
 
-    CmdPtr = (const CFE_HDR_CommandHeader_t *)(const void *)MsgPtr;
+    CmdPtr = (const EdsDataType_CFE_HDR_CommandHeader_t *)(const void *)MsgPtr;
 
     *FcnCode = CmdPtr->Sec.FunctionCode;
 
@@ -66,15 +69,15 @@ CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode)
 {
-    CFE_HDR_CommandHeader_t *CmdPtr;
-    const CCSDS_CommonHdr_t *CommonHdr;
+    EdsDataType_CFE_HDR_CommandHeader_t *CmdPtr;
+    const EdsDataType_CCSDS_CommonHdr_t *CommonHdr;
 
     if (MsgPtr == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    CommonHdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    CommonHdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* This confirms if it is OK to access the pointer as a "CommandHeader" type */
     if (CommonHdr->SecHdrFlags != CCSDS_SecHdrFlags_Cmd)
@@ -82,7 +85,7 @@ CFE_Status_t CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t Fcn
         return CFE_MSG_WRONG_MSG_TYPE;
     }
 
-    CmdPtr = (CFE_HDR_CommandHeader_t *)(void *)MsgPtr;
+    CmdPtr = (EdsDataType_CFE_HDR_CommandHeader_t *)(void *)MsgPtr;
 
     CmdPtr->Sec.FunctionCode = FcnCode;
 

--- a/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_tlm.c
+++ b/cfecfs/edsmsg/fsw/src/cfe_msg_sechdr_tlm.c
@@ -21,6 +21,9 @@
 #include "cfe_msg.h"
 #include "cfe_error.h"
 
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
+
 /*----------------------------------------------------------------
  *
  * Function: CFE_MSG_SetMsgTime
@@ -31,15 +34,15 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
 {
-    CFE_HDR_TelemetryHeader_t *TlmPtr;
-    const CCSDS_CommonHdr_t *  CommonHdr;
+    EdsDataType_CFE_HDR_TelemetryHeader_t *TlmPtr;
+    const EdsDataType_CCSDS_CommonHdr_t *  CommonHdr;
 
     if (MsgPtr == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    CommonHdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    CommonHdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* This confirms if it is OK to access the pointer as a "TelemetryHeader" type */
     if (CommonHdr->SecHdrFlags != CCSDS_SecHdrFlags_Tlm)
@@ -47,7 +50,7 @@ CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Ne
         return CFE_MSG_WRONG_MSG_TYPE;
     }
 
-    TlmPtr = (CFE_HDR_TelemetryHeader_t *)(void *)MsgPtr;
+    TlmPtr = (EdsDataType_CFE_HDR_TelemetryHeader_t *)(void *)MsgPtr;
 
     TlmPtr->Sec.Seconds = NewTime.Seconds;
 
@@ -74,15 +77,15 @@ CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Ne
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time)
 {
-    const CFE_HDR_TelemetryHeader_t *TlmPtr;
-    const CCSDS_CommonHdr_t *        CommonHdr;
+    const EdsDataType_CFE_HDR_TelemetryHeader_t *TlmPtr;
+    const EdsDataType_CCSDS_CommonHdr_t *        CommonHdr;
 
     if (MsgPtr == NULL || Time == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    CommonHdr = (const CCSDS_CommonHdr_t *)MsgPtr;
+    CommonHdr = (const EdsDataType_CCSDS_CommonHdr_t *)MsgPtr;
 
     /* This confirms if it is OK to access the pointer as a "TelemetryHeader" type */
     if (CommonHdr->SecHdrFlags != CCSDS_SecHdrFlags_Tlm)
@@ -90,7 +93,7 @@ CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTim
         return CFE_MSG_WRONG_MSG_TYPE;
     }
 
-    TlmPtr = (const CFE_HDR_TelemetryHeader_t *)(const void *)MsgPtr;
+    TlmPtr = (const EdsDataType_CFE_HDR_TelemetryHeader_t *)(const void *)MsgPtr;
 
     Time->Seconds = TlmPtr->Sec.Seconds;
 

--- a/cfecfs/missionlib/cmake/cfe_mission_eds_interface_parameters.h.in
+++ b/cfecfs/missionlib/cmake/cfe_mission_eds_interface_parameters.h.in
@@ -1,0 +1,12 @@
+/* Generated wrapper based off the real source file location */
+#include "@EDS_FILE_PREFIX@_designparameters.h"
+#include "@EDS_FILE_PREFIX@_interfacedb.h"
+
+#define CFE_SOFTWAREBUS_INTERFACE  @EDS_SYMBOL_PREFIX@_SOFTWAREBUS_INTERFACE
+
+#define EDS_DISPATCH_TABLE_ID(x)  @EDS_SYMBOL_PREFIX@_DispatchTableId_ ## x
+#define EDS_DISPATCH_TABLE_ID_MAX @EDS_SYMBOL_PREFIX@_DispatchTableId_MAX
+#define EDS_INTERFACE_ID(x)       @EDS_SYMBOL_PREFIX@_InterfaceId_ ## x
+#define EDS_INTERFACE_ID_MAX      @EDS_SYMBOL_PREFIX@_InterfaceId_MAX
+#define EDS_INDICATION_ID(x)      @EDS_SYMBOL_PREFIX@_IndicationId_ ## x ## _VALUE
+#define EDS_INDICATION_ID_MAX     @EDS_SYMBOL_PREFIX@_IndicationId_MAX

--- a/cfecfs/missionlib/cmake/edstool-execute-mission.mk
+++ b/cfecfs/missionlib/cmake/edstool-execute-mission.mk
@@ -3,6 +3,7 @@ include edstool-sources.d
 
 LOCAL_STAMPFILE := edstool-complete.stamp
 MISSION_PARAM_HEADER := inc/cfe_mission_eds_parameters.h
+INTFDB_PARAM_HEADER := inc/cfe_mission_eds_interface_parameters.h
 O := $(OBJDIR)
 
 
@@ -19,10 +20,14 @@ all: $(LOCAL_STAMPFILE)
 ALL_EDS_FILES += $(subst ;, ,$(MISSION_EDS_FILELIST))
 ALL_EDS_FILES += $(subst ;, ,$(MISSION_EDS_SCRIPTLIST))
 
-$(LOCAL_STAMPFILE): $(EDSTOOL)  $(MISSION_PARAM_HEADER) $(ALL_EDS_FILES)
+$(LOCAL_STAMPFILE): $(EDSTOOL) $(MISSION_PARAM_HEADER) $(INTFDB_PARAM_HEADER) $(ALL_EDS_FILES)
 	+$(EDSTOOL) -DMAKE_PROGRAM="$(MAKE)" -DOBJDIR=$(OBJDIR) $(ALL_EDS_FILES)
 	$(CMAKE) -E touch "$(@)"
 
 $(MISSION_PARAM_HEADER): $(EDS_CFECFS_MISSIONLIB_SOURCE_DIR)/cmake/cfe_mission_eds_parameters.h.in obj/edstool-buildenv.d
 	@echo "configure_file($(<) $(@))" > src/generate_eds_parameters_h.cmake
 	$(CMAKE) -D MISSION_NAME=$(MISSION_NAME) -D EDS_FILE_PREFIX=$(EDS_FILE_PREFIX) -D EDS_SYMBOL_PREFIX=$(EDS_SYMBOL_PREFIX) -P src/generate_eds_parameters_h.cmake
+
+$(INTFDB_PARAM_HEADER): $(EDS_CFECFS_MISSIONLIB_SOURCE_DIR)/cmake/cfe_mission_eds_interface_parameters.h.in obj/edstool-buildenv.d
+	@echo "configure_file($(<) $(@))" > src/cfe_mission_eds_interface_parameters.cmake
+	$(CMAKE) -D MISSION_NAME=$(MISSION_NAME) -D EDS_FILE_PREFIX=$(EDS_FILE_PREFIX) -D EDS_SYMBOL_PREFIX=$(EDS_SYMBOL_PREFIX) -P src/cfe_mission_eds_interface_parameters.cmake

--- a/cfecfs/missionlib/eds/74-cfe_sb_msg_topic_ids.lua
+++ b/cfecfs/missionlib/eds/74-cfe_sb_msg_topic_ids.lua
@@ -1,0 +1,128 @@
+--
+-- LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
+--
+-- Copyright (c) 2020 United States Government as represented by
+-- the Administrator of the National Aeronautics and Space Administration.
+-- All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+-- -------------------------------------------------------------------------
+-- Lua implementation of the "dispatch tables" as part of the CFS/MissionLib
+--
+-- In this area the EDS processing becomes very specific to CFE/CFS
+-- and how this application will actually use it.  The objective is
+-- to generate the appropriate data structures for "dispatching"
+-- messages from the software bus to the local application.
+-- -------------------------------------------------------------------------
+
+local mts_comp = SEDS.root:find_reference("CFE_SB/MTS", "COMPONENT")
+
+if (type(mts_comp) ~= "userdata") then
+    SEDS.error("CFE_SB/MTS component is not defined")
+    return
+end
+
+local components = {}
+
+-- -----------------------------------------------------
+-- helper function to determine a complete "interface chain"
+-- -----------------------------------------------------
+--[[
+Each Software Bus routing path should involve a chain of interfaces:
+MTS -> PubSub -> (Telecommand|Telemetry) -> Application
+--]]
+
+local function get_chain(inst)
+
+  local chain = { }
+  local found_chain = false
+  local do_get_chain
+
+  do_get_chain = function(inst)
+    if (inst) then
+      found_chain = (inst.component == mts_comp)
+      if (not found_chain) then
+        for i,binding in ipairs(inst.required_links) do
+          chain[1 + #chain] = binding
+          do_get_chain(binding.provinst)
+          if (found_chain) then
+            break
+          end
+          chain[#chain] = nil
+        end
+      end
+    end
+  end
+
+  do_get_chain(inst)
+  return chain[1], chain[2], chain[3]
+end
+
+-- -----------------------------------------------------
+-- Main routine starts here
+-- -----------------------------------------------------
+--[[
+  First, find the chain for each entry in the SEDS.highlevel_interfaces list
+  If it is a CFE_SB interface (pubsub) then identify the MsgId and TopicId
+  Build a reverse-map table for MsgId and TopicId and ensure there are no duplicates
+
+  Also note - this puts the topicid table at the MTS level, ensuring uniqueness of topic IDs
+  across the entire MTS.  Technically only MsgIds need to be unique at the MTS (subnetwork) level,
+  as TopicIDs could be qualified at the access level (CMD or TLM).  However it is just simpler to
+  manage if all the topic IDs are unique too.  This way, all that is needed to pass around is just
+  strictly a topic ID alone, it does not need to be a combination of (topic ID + access intf).
+--]]
+
+mts_comp.msgid_table = {}
+mts_comp.topicid_table = {}
+
+for _,instance in ipairs(SEDS.highlevel_interfaces) do
+  for _,binding in ipairs(instance.required_links) do
+    local tctm, pubsub = get_chain(binding.provinst)
+    if (pubsub) then
+      components[instance.component] = true
+      local chain = {
+        binding = binding,
+        tctm = tctm.reqinst.params[binding.provintf.name](),
+        pubsub = pubsub.reqinst.params[tctm.provintf.name]()
+      }
+      local MsgId = chain.pubsub.MsgId.Value
+      local TopicId = chain.tctm.TopicId
+      -- Build the reverse lookup tables for Message Id and Topic Id
+      -- Ensure that there are no conflicts between these indices
+      if (mts_comp.msgid_table[MsgId]) then
+        local exist_comp = mts_comp.msgid_table[MsgId].binding
+        exist_comp.reqintf:error(string.format("MsgId Conflict on MsgId=%04x/TopicId=%d with %s",MsgId,TopicId,binding.reqintf:get_qualified_name()))
+      else
+        mts_comp.msgid_table[MsgId] = chain
+      end
+      if (mts_comp.topicid_table[TopicId]) then
+        local exist_comp = mts_comp.topicid_table[TopicId].binding
+        exist_comp.reqintf:error(string.format("TopicId Conflict on MsgId=%04x/TopicId=%d with %s",MsgId,TopicId,binding.reqintf:get_qualified_name()))
+      else
+        mts_comp.topicid_table[TopicId] = chain
+      end
+    end
+  end
+end
+
+-- Export the findings via the SEDS global
+SEDS.mts_info = {
+    mts_component = mts_comp,  -- The base (low level) MTS subnetwork component
+    component_set = components -- The keys of this table are the components that use this MTS
+}
+
+--SEDS.error("Stop")

--- a/cfecfs/missionlib/eds/75-cfe_sb_dispatch_tables.lua
+++ b/cfecfs/missionlib/eds/75-cfe_sb_dispatch_tables.lua
@@ -29,447 +29,274 @@
 -- -------------------------------------------------------------------------
 
 local global_sym_prefix = SEDS.get_define("MISSION_NAME")
-local global_file_prefix = global_sym_prefix and string.lower(global_sym_prefix) or "eds"
 global_sym_prefix = global_sym_prefix and string.upper(global_sym_prefix) or "EDS"
-local mts_comp = SEDS.root:find_reference("CFE_SB/MTS", "COMPONENT")
 
-local components = {}
-local msgid_table = {}
-local topicid_table = {}
+local components = SEDS.mts_info.component_set
 local total_intfs = {}
-local interface_list = {}
-local indication_id = 0
+
 
 -- -----------------------------------------------------
 -- helper function to generate software bus component/interface definitions
 -- -----------------------------------------------------
-local function write_c_command_defs(hdrout,desc,cmds)
-  if (cmds) then
-    hdrout:write("struct " .. desc)
-    hdrout:start_group("{")
-    for i,cmd in ipairs(cmds) do
-      hdrout:start_group(string.format("int32 (*%s_%s)(", cmd.intf.name, cmd.refnode.name))
-      for j,arg in ipairs(cmd.args) do
-        hdrout:append_previous(",")
-        hdrout:write(string.format("const %-50s *%s",arg.type.header_data.typedef_name,arg.name))
-      end
-      hdrout:end_group(");")
-    end
-    hdrout:end_group("}")
-    hdrout:add_whitespace(1)
+
+local function get_mapping_info(desc, intftype)
+  return {
+    dispatchid = string.format("%s_%s", desc, intftype.name),
+    dispatchtype = intftype:get_ctype_basename("DispatchTable_" .. desc)
+  }
+end
+
+local function append_list(list_combined, list_in)
+  for _,val in ipairs(list_in) do
+    list_combined[1 + #list_combined] = val
   end
 end
 
-
 -- -----------------------------------------------------
--- helper function to determine a complete "interface chain"
+-- helper function to generate software bus component/interface definitions
 -- -----------------------------------------------------
---[[
-Each Software Bus routing path should involve a chain of interfaces:
-MTS -> PubSub -> (Telecommand|Telemetry) -> Application
---]]
+local function write_intfcmd_data(hdrout,reqintf)
+  local ctypedef_name
 
-local function get_chain(inst)
-
-  local chain = { }
-  local found_chain = false
-
-  local function do_get_chain(inst)
-    if (inst) then
-      found_chain = (inst.component == mts_comp)
-      if (not found_chain) then
-        for i,binding in ipairs(inst.required_links) do
-          chain[1 + #chain] = binding
-          do_get_chain(binding.provinst)
-          if (found_chain) then
-            break
+  if (#reqintf.intf_commands > 0) then
+    local cmdstructname = reqintf:get_ctype_basename("Commands")
+    hdrout:write(string.format("struct %s", cmdstructname))
+    hdrout:start_group("{")
+    for _,cmd in ipairs(reqintf.intf_commands) do
+      if (cmd.subcommand_arg) then
+        for _,deriv in ipairs(cmd.args[cmd.subcommand_arg].type:get_references("derivatives")) do
+          hdrout:add_documentation(string.format("Handler function for %s messages", deriv.name))
+          hdrout:start_group(string.format("int32_t (*%s)(",deriv.name .. "_" .. cmd.refnode.name))
+          for i,arg in ipairs(cmd.args) do
+            hdrout:append_previous(",")
+            local argtype = (i == cmd.subcommand_arg) and deriv or arg.type
+            hdrout:write(string.format("const %s *%s", argtype.header_data.typedef_name, arg.name))
           end
-          chain[#chain] = nil
+          hdrout:end_group(");")
+        end
+      else
+        hdrout:start_group(string.format("int32_t (*%s)(",cmd.refnode.name))
+        for i,arg in ipairs(cmd.args) do
+          hdrout:append_previous(",")
+          hdrout:write(string.format("const %s *%s", arg.type.header_data.typedef_name, arg.name))
+        end
+        hdrout:end_group(");")
+      end
+    end
+    hdrout:end_group("};")
+    ctypedef_name = SEDS.to_ctype_typedef(reqintf, "Commands")
+    hdrout:write(string.format("typedef struct %s %s;", cmdstructname, ctypedef_name))
+    hdrout:add_whitespace(1)
+  end
+
+  return ctypedef_name
+end
+
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+
+local function write_reqintf_data(hdrout,reqintf)
+
+  local intfcmds = {}
+
+  for cmd in reqintf.type:iterate_subtree("COMMAND") do
+    local args = {}
+    local subcommand_arg
+
+    -- Determine if any of the EDS-defined commands have subcommands
+    -- A "subcommand" in this context maps to the traditional CFE commands, where
+    -- each one maps to a different FunctionCode value in the secondary header.
+    -- NOTE: This is specifically checking for items that follow a pattern of
+    -- being derived from the same basetype, and have a ValueConstraint on a field
+    -- named "Sec.FunctionCode".  If found, subcommand_arg will be set to the position
+    -- in the argument list.  In practice, this value can only be undefined or 1.
+    for i,stype,refnode in cmd:iterate_members({ reqintf }) do
+      if (not stype or not refnode or stype.entity_type == "GENERIC_TYPE") then
+        reqintf:error(string.format("Undefined %s", cmd), refnode)
+      else
+        args[i] = { type = stype, name = refnode.name }
+        if (stype.derivative_decisiontree_map and
+          stype.derivative_decisiontree_map.entities and
+          stype.derivative_decisiontree_map.entities["Sec.FunctionCode"]) then
+          subcommand_arg = i
         end
       end
     end
+
+    intfcmds[1 + #intfcmds] = { refnode = cmd, args = args, subcommand_arg = subcommand_arg }
   end
 
-  do_get_chain(inst)
-  return chain[1], chain[2], chain[3]
+  -- Export information by saving in the DOM tree
+  reqintf.intf_commands = intfcmds
+  reqintf.mapping_info.cmdstruct_typedef = write_intfcmd_data(hdrout,reqintf)
+
+  hdrout:add_whitespace(1)
+
 end
 
-for _,instance in ipairs(SEDS.highlevel_interfaces) do
-  for _,binding in ipairs(instance.required_links) do
-    local tctm, pubsub = get_chain(binding.provinst)
-    if (pubsub) then
-      components[instance.component] = true
-      local chain = {
-        binding = binding,
-        tctm = tctm.reqinst.params[binding.provintf.name](),
-        pubsub = pubsub.reqinst.params[tctm.provintf.name]()
-      }
-      local MsgId = chain.pubsub.MsgId.Value
-      local TopicId = chain.tctm.TopicId
-      -- Build the reverse lookup tables for Message Id and Topic Id
-      -- Ensure that there are no conflicts between these indices
-      if (msgid_table[MsgId]) then
-        local exist_comp = msgid_table[MsgId].binding
-        exist_comp.reqintf:error(string.format("MsgId Conflict on MsgId=%04x/TopicId=%d with %s",MsgId,TopicId,binding.reqintf:get_qualified_name()))
-      else
-        msgid_table[MsgId] = chain
-      end
-      if (topicid_table[TopicId]) then
-        local exist_comp = topicid_table[TopicId].binding
-        exist_comp.reqintf:error(string.format("TopicId Conflict on MsgId=%04x/TopicId=%d with %s",MsgId,TopicId,binding.reqintf:get_qualified_name()))
-      else
-        topicid_table[TopicId] = chain
-      end
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+local function write_dispatch_table_cdecl(hdrout, intftype_mapping_info)
+
+  hdrout:add_documentation(string.format("Dispatch table for %s interface", intftype_mapping_info.intftype.name))
+  hdrout:write(string.format("struct %s", intftype_mapping_info.dispatchtype))
+  hdrout:start_group("{")
+  for reqintf in intftype_mapping_info.component:iterate_subtree("REQUIRED_INTERFACE") do
+    if (reqintf.type == intftype_mapping_info.intftype) then
+      hdrout:add_documentation(string.format("Dispatch table associated with %s interface", reqintf.name))
+      hdrout:write(string.format("%-60s %s;", reqintf.mapping_info.cmdstruct_typedef, reqintf.name))
     end
   end
+  hdrout:end_group("};")
+  hdrout:write(string.format("typedef struct %-50s %s;", intftype_mapping_info.dispatchtype,
+    SEDS.to_ctype_typedef(intftype_mapping_info.dispatchtype, true)))
+
+  hdrout:add_whitespace(1)
 end
 
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+
+local function write_interface_header(hdrout,comp)
+
+  local component_intftype_list = {}
+
+  hdrout:section_marker(comp.name .. " Command Handlers")
+  local component_intftypes = {}
+  local desc = comp:get_flattened_name()
+  for reqintf in comp:iterate_subtree("REQUIRED_INTERFACE") do
+
+    -- Export information by saving in the DOM tree
+    reqintf.mapping_info = get_mapping_info(desc, reqintf.type)
+
+    -- This adds an "intf_commands" member that is a list of descriptors for the commands on this intf
+    -- The descriptor has the following info in it:
+    --  refnode : points to the cmd node in the DOM tree
+    --  args : a list of arguments to that command (generally always length of 1 in CFE)
+    --  subcommand_arg : the index of the argument that has subcommands (derivatives).  Should be 1 for CFE ground commands, nil on everything else.
+    write_reqintf_data(hdrout,reqintf)
+
+    -- If this yielded a non-empty list, then merge it with the component_intftypes
+    -- This builds the complete set of interface types within this component
+    if (#reqintf.intf_commands > 0) then
+      local compcmds = component_intftypes[reqintf.type]
+
+      if (not compcmds) then
+        compcmds = {}
+        component_intftypes[reqintf.type] = compcmds
+      end
+
+      -- Append this set of commands to the
+      append_list(compcmds, reqintf.intf_commands)
+    end
+
+  end
+
+  -- This gets the complete set of interface types in this component in a sorted order
+  local sorted_local_intftypes = SEDS.sorted_keys(component_intftypes, function(a,b)
+    return a.name < b.name
+  end)
+
+  hdrout:section_marker(comp.name .. " Dispatch Tables")
+  for intftype in sorted_local_intftypes do
+
+    local intftype_mapping_info = get_mapping_info(desc, intftype)
+
+    intftype_mapping_info.component = comp
+    intftype_mapping_info.intftype = intftype
+
+    component_intftype_list[1 + #component_intftype_list] = intftype_mapping_info
+
+    write_dispatch_table_cdecl(hdrout, intftype_mapping_info)
+
+  end
+
+  return component_intftype_list
+end
+
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+
+local function write_dispatch_header(hdrout,entry)
+
+  -- In CFE usage, generally all of the interfaces for the SB that FSW accesses only have one
+  -- command, which is a generic indication/activation of that interface.  In this case, the
+  -- dispatch invocation can be simplified, it doesn't need an extra indication parameter if
+  -- there is just a single one.
+
+  local command_count = SEDS.count_results(entry.intftype:iterate_subtree("COMMAND"))
+
+  hdrout:start_group(string.format("static inline int32_t EdsDispatch_%s(",entry.dispatchid))
+  hdrout:write(string.format("%-65s *Message,", "const CFE_SB_Buffer_t"))
+  hdrout:write(string.format("%-65s *DispatchTable","const struct " .. entry.dispatchtype))
+
+  -- Only need the caller to pass in an ID here if there is more than one command defined.
+  if (command_count > 1) then
+    hdrout:write(string.format("%-65s IndicationId,", "uint16"))
+  end
+  hdrout:end_group(")")
+  hdrout:start_group("{")
+  hdrout:start_group("return CFE_MSG_EdsDispatch(")
+  hdrout:write(string.format("%s_InterfaceId_%s,", global_sym_prefix, entry.intftype:get_ctype_basename()))
+  if (command_count > 1) then
+    hdrout:write(string.format("IndicationId - %s_%s,", global_sym_prefix, entry.intftype:get_ctype_basename("IndicationId") .. "_BASE"))
+  else
+    hdrout:write("1,")
+  end
+  hdrout:write(string.format("%s_DispatchTableId_%s,", global_sym_prefix, entry.dispatchid))
+  hdrout:write("Message,")
+  hdrout:write("DispatchTable")
+  hdrout:end_group(");")
+  hdrout:end_group("}")
+
+end
+
+-- -----------------------------------------------------
+-- Main routine starts here
+-- -----------------------------------------------------
+--[[
+--]]
+
+
 for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
-  local first_intf = 1 + #total_intfs
-  local hdrout = SEDS.output_open(SEDS.to_filename("interface.h", ds.name),ds.xml_filename)
-  hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("typedefs.h", ds.name)))
+  local ds_intftype_list = {}
+  local hdrout
+
+  hdrout = SEDS.output_open(SEDS.to_filename("interface.h", ds.name),ds.xml_filename)
+
+  hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("datatypes.h", ds.name)))
   hdrout:add_whitespace(1)
 
   for comp in ds:iterate_subtree("COMPONENT") do
     if (components[comp]) then
-      hdrout:section_marker(comp.name .. " Command Handlers")
-      local localintfs = {}
-      local desc = comp:get_flattened_name()
-      for reqintf in comp:iterate_subtree("REQUIRED_INTERFACE") do
-        local intfcmds = {}
-        for cmd in reqintf.type:iterate_subtree("COMMAND") do
-          local args = {}
-          local subcommand_arg
-          for i,stype,refnode in cmd:iterate_members({ reqintf }) do
-            if (not stype or not refnode or stype.entity_type == "GENERIC_TYPE") then
-              reqintf:error(string.format("Undefined %s", cmd), refnode)
-            else
-              args[i] = { type = stype, name = refnode.name }
-              if (stype.derivative_decisiontree_map and
-                stype.derivative_decisiontree_map.entities and
-                stype.derivative_decisiontree_map.entities["Sec.FunctionCode"]) then
-                subcommand_arg = i
-              end
-            end
-          end
-
-          intfcmds[1 + #intfcmds] = { refnode = cmd, args = args, subcommand_arg = subcommand_arg }
-
-          local compcmds = localintfs[reqintf.type]
-          if (not compcmds) then
-            compcmds = {}
-            localintfs[reqintf.type] = compcmds
-          end
-          compcmds[1 + #compcmds] = intfcmds[#intfcmds]
-        end
-        reqintf.mapping_info = {
-          dispatchid = string.format("%s_%s", desc, reqintf.type.name)
-        }
-        if (#intfcmds > 0) then
-          local cmdstructname = string.format("%s_Commands", reqintf:get_flattened_name())
-          hdrout:write(string.format("struct %s", cmdstructname))
-          hdrout:start_group("{")
-          for _,cmd in ipairs(intfcmds) do
-            if (cmd.subcommand_arg) then
-              for _,deriv in ipairs(cmd.args[cmd.subcommand_arg].type:get_references("derivatives")) do
-                hdrout:add_documentation(string.format("Handler function for %s messages", deriv.name))
-                hdrout:start_group(string.format("int32_t (*%s)(",deriv.name .. "_" .. cmd.refnode.name))
-                for i,arg in ipairs(cmd.args) do
-                  hdrout:append_previous(",")
-                  local argtype = (i == cmd.subcommand_arg) and deriv or arg.type
-                  hdrout:write(string.format("const %s *%s", argtype.header_data.typedef_name, arg.name))
-                end
-                hdrout:end_group(");")
-              end
-            else
-              hdrout:start_group(string.format("int32_t (*%s)(",cmd.refnode.name))
-              for i,arg in ipairs(cmd.args) do
-                hdrout:append_previous(",")
-                hdrout:write(string.format("const %s *%s", arg.type.header_data.typedef_name, arg.name))
-              end
-              hdrout:end_group(");")
-            end
-          end
-          hdrout:end_group("};")
-          reqintf.mapping_info.cmdstruct_typedef = cmdstructname .. "_t"
-          hdrout:write(string.format("typedef struct %s %s;", cmdstructname, reqintf.mapping_info.cmdstruct_typedef))
-          hdrout:add_whitespace(1)
-        end
-        reqintf.intf_commands = intfcmds
-        hdrout:add_whitespace(1)
-
-      end
-      local sorted_localintfs = {}
-      for intf in pairs(localintfs) do
-        sorted_localintfs[1 + #sorted_localintfs] = intf
-      end
-      table.sort(sorted_localintfs, function(a,b)
-        return a.name < b.name
-      end)
-
-      hdrout:section_marker(comp.name .. " Dispatch Tables")
-      for _,intf in ipairs(sorted_localintfs) do
-        local output_name = string.format("%s_%s", desc, intf.name)
-        total_intfs[1 + #total_intfs] = { component = comp, intf = intf, output_name = output_name }
-        hdrout:add_documentation(string.format("Dispatch table for %s %s interface", ds.name, intf.name))
-        hdrout:write(string.format("struct %s_DispatchTable", output_name))
-        hdrout:start_group("{")
-        for reqintf in comp:iterate_subtree("REQUIRED_INTERFACE") do
-          if (reqintf.type == intf) then
-            hdrout:add_documentation(string.format("Dispatch table associated with %s interface", reqintf.name))
-            hdrout:write(string.format("%-60s %s;", reqintf.mapping_info.cmdstruct_typedef, reqintf.name))
-          end
-        end
-        hdrout:end_group("};")
-        hdrout:write(string.format("typedef struct %s_DispatchTable %s_DispatchTable_t;", output_name,output_name))
-        hdrout:add_whitespace(1)
-      end
+      local component_intftype_list = write_interface_header(hdrout,comp)
+      append_list(ds_intftype_list, component_intftype_list)
     end
   end
 
   SEDS.output_close(hdrout)
 
   hdrout = SEDS.output_open(SEDS.to_filename("dispatcher.h", ds.name), ds.xml_filename)
+
   hdrout:write(string.format("#include \"cfe_msg_dispatcher.h\""))
   hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("interfacedb.h", global_sym_prefix)))
   hdrout:write(string.format("#include \"%s\"", SEDS.to_filename("interface.h", ds.name)))
   hdrout:add_whitespace(1)
 
   hdrout:section_marker("Dispatch Function Prototypes")
-  for i = first_intf,#total_intfs do
-    local entry = total_intfs[i]
-    hdrout:start_group(string.format("static inline int32_t %s_Dispatch(",entry.output_name))
-    hdrout:write(string.format("%-65s IndicationId,", entry.intf:get_flattened_name() .. "_IndicationId_t"))
-    hdrout:write(string.format("%-65s *Message,", "const CFE_SB_Buffer_t"))
-    hdrout:write(string.format("%-65s *DispatchTable","const " .. entry.output_name .. "_DispatchTable_t"))
-    hdrout:end_group(")")
-    hdrout:start_group("{")
-    hdrout:start_group("return CFE_MSG_EdsDispatch(")
-    hdrout:write(string.format("%s,", entry.intf:get_flattened_name() .. "_ID"))
-    hdrout:write(string.format("IndicationId - %s,", entry.intf:get_flattened_name() .. "_INDICATION_BASE"))
-    hdrout:write(string.format("%s_DISPATCHTABLE_ID,",entry.output_name))
-    hdrout:write("Message,")
-    hdrout:write("DispatchTable")
-    hdrout:end_group(");")
-    hdrout:end_group("}")
+  for _,entry in ipairs(ds_intftype_list) do
+    write_dispatch_header(hdrout, entry)
   end
 
   SEDS.output_close(hdrout)
+
+  append_list(total_intfs, ds_intftype_list)
+
 end
 
-local hdrout = SEDS.output_open(SEDS.to_filename("interfacedb.h"))
-
-for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
-  for intftype in ds:iterate_subtree("DECLARED_INTERFACE") do
-    interface_list[1 + #interface_list] = intftype
-    local command_list = {}
-    for cmd in intftype:iterate_subtree("COMMAND") do
-      command_list[1 + #command_list] = cmd
-    end
-    if (#command_list > 0) then
-      hdrout:write("typedef enum")
-      hdrout:start_group("{")
-      indication_id = 1 + indication_id
-      hdrout:write(intftype:get_flattened_name() .. "_INDICATION_BASE = " .. indication_id)
-      for _,cmd in ipairs(command_list) do
-        hdrout:append_previous(",")
-        hdrout:write(cmd:get_flattened_name() .. "_ID")
-        indication_id = 1 + indication_id
-      end
-      hdrout:end_group(string.format("} %s;", intftype:get_flattened_name() .. "_IndicationId_t"))
-      hdrout:add_whitespace(1)
-    end
-  end
-end
-
-hdrout:write("enum")
-hdrout:start_group("{")
-hdrout:write(string.format("%s_DISPATCHTABLE_ID_RESERVED = 0,", global_sym_prefix))
-for _,entry in ipairs(total_intfs) do
-  hdrout:write(entry.output_name .. "_DISPATCHTABLE_ID,")
-end
-hdrout:write(string.format("%s_DISPATCHTABLE_ID_MAX", global_sym_prefix))
-hdrout:end_group("};")
-hdrout:add_whitespace(1)
-
-hdrout:write("enum")
-hdrout:start_group("{")
-hdrout:write(string.format("%s_INTERFACE_ID_RESERVED = 0,", global_sym_prefix))
-for _,intftype in ipairs(interface_list) do
-  hdrout:write(intftype:get_flattened_name() .. "_ID,")
-end
-hdrout:write(string.format("%s_INTERFACE_ID_MAX", global_sym_prefix))
-hdrout:end_group("};")
-hdrout:add_whitespace(1)
-
-hdrout:write(string.format("extern const struct CFE_MissionLib_SoftwareBus_Interface %s_SOFTWAREBUS_INTERFACE;", global_sym_prefix))
-
-
-SEDS.output_close(hdrout)
-
-
-local dbout = SEDS.output_open(SEDS.to_filename("interfacedb_impl.c"))
-
-dbout:write("#include \"edslib_database_types.h\"")
-dbout:write("#include \"cfe_missionlib_database_types.h\"")
-dbout:write(string.format("#include \"%s\"",SEDS.to_filename("interfacedb.h")))
-dbout:write(string.format("#include \"%s\"",SEDS.to_filename("master_index.h")))
-for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
-  dbout:write(string.format("#include \"%s\"",SEDS.to_filename("interface.h", ds.name)))
-end
-dbout:add_whitespace(1)
-
-for tid = 1,SEDS.get_define("CFE_MISSION/MAX_TOPICID") do
-  local chain = topicid_table[tid]
-  if (chain) then
-    local intf = chain.binding.reqintf
-    local cmdlist = intf.intf_commands or {}
-    local arg_list = {}
-    for j,cmd in ipairs(cmdlist) do
-      if (#cmd.args > 0) then
-        arg_list[j] = string.format("%s_%s_ARGUMENT_LIST",intf:get_flattened_name(), cmd.refnode.name)
-        dbout:write(string.format("static const CFE_MissionLib_Argument_Entry_t %s[] =", arg_list[j]))
-        dbout:start_group("{")
-        for _,arg in ipairs(cmd.args) do
-          dbout:append_previous(",")
-          dbout:start_group("{")
-          local ds = arg.type:find_parent(SEDS.basenode_filter)
-          dbout:write(string.format(".AppIndex = %s,", ds.edslib_refobj_global_index))
-          dbout:write(string.format(".TypeIndex = %s", arg.type.edslib_refobj_local_index))
-          dbout:end_group("}")
-        end
-        dbout:end_group("};")
-        dbout:add_whitespace(1)
-      end
-    end
-
-    for j,cmd in ipairs(cmdlist) do
-      if (cmd.subcommand_arg) then
-        local derivlist = cmd.args[cmd.subcommand_arg].type.edslib_derivtable_list
-        dbout:write(string.format("static const CFE_MissionLib_Subcommand_Entry_t %s_%s_SUBCOMMAND_LIST[] =",
-          intf:get_flattened_name(), cmd.refnode.name))
-        dbout:start_group("{")
-        for _,deriv in ipairs(derivlist) do
-          dbout:append_previous(",")
-          dbout:start_group("{")
-          dbout:write(string.format(".DispatchOffset = offsetof(struct %s_Commands,%s)",
-            intf:get_flattened_name(), deriv.name .. "_" .. cmd.refnode.name))
-          dbout:end_group("}")
-        end
-        dbout:end_group("};")
-        dbout:add_whitespace(1)
-      end
-    end
-
-    local cmd_def = string.format("%s_COMMANDS",intf:get_flattened_name())
-    dbout:write(string.format("static const CFE_MissionLib_Command_Definition_Entry_t %s[] =",cmd_def))
-    dbout:start_group("{")
-    for j,cmd in ipairs(cmdlist) do
-      dbout:append_previous(",")
-      dbout:start_group("{")
-      if (cmd.subcommand_arg) then
-        dbout:write(string.format(".SubcommandArg = %d,", cmd.subcommand_arg))
-        dbout:write(string.format(".SubcommandCount = %d,",
-          #cmd.args[cmd.subcommand_arg].type.edslib_derivtable_list))
-        dbout:write(string.format(".SubcommandList = %s_%s_SUBCOMMAND_LIST",
-          intf:get_flattened_name(), cmd.refnode.name))
-      end
-      if (arg_list[j]) then
-        dbout:append_previous(",")
-        dbout:write(string.format(".ArgumentList = %s", arg_list[j]))
-      end
-      dbout:end_group("}")
-    end
-    dbout:end_group("};")
-    dbout:add_whitespace(1)
-  end
-end
-
-local objname = string.format("%s_TOPICID_LOOKUP", global_sym_prefix)
-local base_topicid = 1
-dbout:write(string.format("static const CFE_MissionLib_TopicId_Entry_t %s[%d] =", objname, SEDS.get_define("CFE_MISSION/MAX_TOPICID") - base_topicid))
-dbout:start_group("{")
-for tid = 1,SEDS.get_define("CFE_MISSION/MAX_TOPICID") do
-  local chain = topicid_table[tid]
-  if (chain) then
-    dbout:append_previous(",")
-    dbout:write(string.format("[%d] =", chain.tctm.TopicId - base_topicid))
-    dbout:start_group("{")
-    dbout:write(string.format(".DispatchTableId = %s_DISPATCHTABLE_ID,", chain.binding.reqintf.mapping_info.dispatchid))
-    dbout:write(string.format(".DispatchStartOffset = offsetof(%s_DispatchTable_t,%s),",
-      chain.binding.reqintf.mapping_info.dispatchid,
-      chain.binding.reqintf.name))
-    dbout:write(string.format(".InterfaceId = %s_ID,", chain.binding.reqintf.type:get_flattened_name()))
-    dbout:write(string.format(".TopicName = \"%s\",", chain.binding.reqintf:get_qualified_name()))
-    dbout:write(string.format(".CommandList = %s_COMMANDS",chain.binding.reqintf:get_flattened_name()))
-    dbout:end_group("}")
-  end
-end
-dbout:end_group("};")
-dbout:add_whitespace(1)
-
-dbout:section_marker("Interface Definitions")
-for _,intftype in ipairs(interface_list) do
-  if (intftype:find_first("COMMAND")) then
-    dbout:write(string.format("static const CFE_MissionLib_Command_Prototype_Entry_t %s_BASE_COMMAND_LIST[] =", intftype:get_flattened_name()))
-    dbout:start_group("{")
-    for cmd in intftype:iterate_subtree("COMMAND") do
-      dbout:append_previous(",")
-      dbout:start_group("{")
-      dbout:write(string.format(".CommandName = \"%s\",", cmd.name))
-      local arg_count = 0
-      for _ in cmd:iterate_subtree("ARGUMENT") do
-        arg_count = 1 + arg_count
-      end
-      dbout:write(string.format(".NumArguments = %d", arg_count))
-      dbout:end_group("}")
-    end
-    dbout:end_group("};")
-    dbout:add_whitespace(1)
-  end
-end
-
-dbout:write(string.format("static const CFE_MissionLib_InterfaceId_Entry_t %s_INTERFACEID_LOOKUP[] =", global_sym_prefix))
-dbout:start_group("{")
-for _,intftype in ipairs(interface_list) do
-  local command_count = 0
-  local intfname = intftype:get_qualified_name()
-  for cmd in intftype:iterate_subtree("COMMAND") do
-    command_count = 1 + command_count
-  end
-  dbout:append_previous(",")
-  dbout:start_group("{")
-  dbout:write(string.format(".NumCommands = %d,", command_count))
-  dbout:write(string.format(".InterfaceName = \"%s\",", intfname))
-  if (command_count > 0) then
-    dbout:write(string.format(".CommandList = %s,", intftype:get_flattened_name() .. "_BASE_COMMAND_LIST"))
-  end
-  -- Only include topicid lookup info on the TC/TM interfaces
-  -- this is a bit of a hack as this doesn't really belong here.
-  if (intfname == "CFE_SB/Telecommand" or intfname == "CFE_SB/Telemetry") then
-    dbout:write(string.format(".NumTopics = %d,", SEDS.get_define("CFE_MISSION/MAX_TOPICID") - base_topicid))
-    dbout:write(string.format(".TopicList = %s_TOPICID_LOOKUP,", global_sym_prefix))
-  end
-  dbout:end_group("}")
-end
-dbout:end_group("};")
-dbout:add_whitespace(1)
-
-dbout:section_marker("Instance Name Table")
-dbout:write("#define DEFINE_TGTNAME(x)       #x,")
-dbout:write(string.format("static const char * const %s_INSTANCE_LIST[] =", global_sym_prefix))
-dbout:write("{")
-dbout:write("#include \"cfe_mission_tgtnames.inc\"")
-dbout:write("    NULL")
-dbout:write("};")
-
-dbout:section_marker("Summary Object")
-dbout:write(string.format("const struct CFE_MissionLib_SoftwareBus_Interface %s_SOFTWAREBUS_INTERFACE =", global_sym_prefix))
-dbout:start_group("{")
-    dbout:write(string.format(".NumInterfaces = %d,", #interface_list))
-    dbout:write(string.format(".InterfaceList = %s_INTERFACEID_LOOKUP,", global_sym_prefix))
-    dbout:write(string.format(".InstanceList = %s_INSTANCE_LIST", global_sym_prefix))
-dbout:end_group("};")
-dbout:add_whitespace(1)
-
-SEDS.output_close(dbout)
+-- Export the list of all intfs via the "mts_info" in the SEDS global
+SEDS.mts_info.total_intfs = total_intfs

--- a/cfecfs/missionlib/eds/76-cfe_sb_interfacedb_global.lua
+++ b/cfecfs/missionlib/eds/76-cfe_sb_interfacedb_global.lua
@@ -1,0 +1,262 @@
+--
+-- LEW-19710-1, CCSDS SOIS Electronic Data Sheet Implementation
+--
+-- Copyright (c) 2020 United States Government as represented by
+-- the Administrator of the National Aeronautics and Space Administration.
+-- All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+-- -------------------------------------------------------------------------
+-- Lua implementation of the "dispatch tables" as part of the CFS/MissionLib
+--
+-- In this area the EDS processing becomes very specific to CFE/CFS
+-- and how this application will actually use it.  The objective is
+-- to generate the appropriate data structures for "dispatching"
+-- messages from the software bus to the local application.
+-- -------------------------------------------------------------------------
+
+local global_sym_prefix = SEDS.get_define("MISSION_NAME")
+global_sym_prefix = global_sym_prefix and string.upper(global_sym_prefix) or "EDS"
+
+local components = SEDS.mts_info.component_set
+local topicid_table = SEDS.mts_info.mts_component.topicid_table
+
+local total_intfs = SEDS.mts_info.total_intfs
+local interface_list = {}
+
+
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+
+-- -----------------------------------------------------
+-- helper function to generate software bus component/interface definitions
+-- -----------------------------------------------------
+
+
+-- -----------------------------------------------------
+-- Main routine starts here
+-- -----------------------------------------------------
+--[[
+--]]
+local hdrout = SEDS.output_open(SEDS.to_filename("interfacedb.h"))
+
+hdrout:write("enum")
+hdrout:start_group("{")
+for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
+  for intftype in ds:iterate_subtree("DECLARED_INTERFACE") do
+    interface_list[1 + #interface_list] = intftype
+    local command_list = {}
+    for cmd in intftype:iterate_subtree("COMMAND") do
+      command_list[1 + #command_list] = cmd
+    end
+    if (#command_list > 0) then
+      hdrout:write(string.format("%s_%s_BASE,", global_sym_prefix, intftype:get_ctype_basename("IndicationId")))
+      for _,cmd in ipairs(command_list) do
+        hdrout:write(string.format("%s_%s_VALUE,", global_sym_prefix, cmd:get_ctype_basename("IndicationId")))
+      end
+      hdrout:add_whitespace(1)
+    end
+  end
+end
+hdrout:write(string.format("%s_%s_MAX,", global_sym_prefix, "IndicationId"))
+hdrout:end_group("};")
+hdrout:add_whitespace(1)
+
+hdrout:write("enum")
+hdrout:start_group("{")
+hdrout:write(string.format("%s_DispatchTableId_RESERVED = 0,", global_sym_prefix))
+for _,entry in ipairs(total_intfs) do
+  hdrout:write(string.format("%s_DispatchTableId_%s,", global_sym_prefix, entry.dispatchid))
+end
+hdrout:write(string.format("%s_DispatchTableId_MAX", global_sym_prefix))
+hdrout:end_group("};")
+hdrout:add_whitespace(1)
+
+hdrout:write("enum")
+hdrout:start_group("{")
+hdrout:write(string.format("%s_InterfaceId_RESERVED = 0,", global_sym_prefix))
+for _,intftype in ipairs(interface_list) do
+  hdrout:write(string.format("%s_InterfaceId_%s,", global_sym_prefix, intftype:get_ctype_basename()))
+end
+hdrout:write(string.format("%s_InterfaceId_MAX", global_sym_prefix))
+hdrout:end_group("};")
+hdrout:add_whitespace(1)
+
+hdrout:write(string.format("extern const struct CFE_MissionLib_SoftwareBus_Interface %s_SOFTWAREBUS_INTERFACE;", global_sym_prefix))
+
+
+SEDS.output_close(hdrout)
+
+
+local dbout = SEDS.output_open(SEDS.to_filename("interfacedb_impl.c"))
+
+dbout:write("#include \"edslib_database_types.h\"")
+dbout:write("#include \"cfe_missionlib_database_types.h\"")
+dbout:write(string.format("#include \"%s\"",SEDS.to_filename("interfacedb.h")))
+dbout:write(string.format("#include \"%s\"",SEDS.to_filename("master_index.h")))
+for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
+  dbout:write(string.format("#include \"%s\"",SEDS.to_filename("interface.h", ds.name)))
+end
+dbout:add_whitespace(1)
+
+for tid = 1,SEDS.get_define("CFE_MISSION/MAX_TOPICID") do
+  local chain = topicid_table[tid]
+  if (chain) then
+    local intf = chain.binding.reqintf
+    local cmdlist = intf.intf_commands or {}
+    local arg_list = {}
+    for j,cmd in ipairs(cmdlist) do
+      if (#cmd.args > 0) then
+        arg_list[j] = string.format("%s_%s_ARGUMENT_LIST",intf:get_flattened_name(), cmd.refnode.name)
+        dbout:write(string.format("static const CFE_MissionLib_Argument_Entry_t %s[] =", arg_list[j]))
+        dbout:start_group("{")
+        for _,arg in ipairs(cmd.args) do
+          dbout:append_previous(",")
+          dbout:start_group("{")
+          local ds = arg.type:find_parent(SEDS.basenode_filter)
+          dbout:write(string.format(".AppIndex = %s,", ds.edslib_refobj_global_index))
+          dbout:write(string.format(".TypeIndex = %s", arg.type.edslib_refobj_local_index))
+          dbout:end_group("}")
+        end
+        dbout:end_group("};")
+        dbout:add_whitespace(1)
+      end
+    end
+
+    for j,cmd in ipairs(cmdlist) do
+      if (cmd.subcommand_arg) then
+        local derivlist = cmd.args[cmd.subcommand_arg].type.edslib_derivtable_list
+        dbout:write(string.format("static const CFE_MissionLib_Subcommand_Entry_t %s_%s_SUBCOMMAND_LIST[] =",
+          intf:get_flattened_name(), cmd.refnode.name))
+        dbout:start_group("{")
+        for _,deriv in ipairs(derivlist) do
+          dbout:append_previous(",")
+          dbout:start_group("{")
+          dbout:write(string.format(".DispatchOffset = offsetof(struct %s, %s)",
+            intf:get_ctype_basename("Commands"), deriv.name .. "_" .. cmd.refnode.name))
+          dbout:end_group("}")
+        end
+        dbout:end_group("};")
+        dbout:add_whitespace(1)
+      end
+    end
+
+    local cmd_def = string.format("%s_COMMANDS",intf:get_flattened_name())
+    dbout:write(string.format("static const CFE_MissionLib_Command_Definition_Entry_t %s[] =",cmd_def))
+    dbout:start_group("{")
+    for j,cmd in ipairs(cmdlist) do
+      dbout:append_previous(",")
+      dbout:start_group("{")
+      if (cmd.subcommand_arg) then
+        dbout:write(string.format(".SubcommandArg = %d,", cmd.subcommand_arg))
+        dbout:write(string.format(".SubcommandCount = %d,",
+          #cmd.args[cmd.subcommand_arg].type.edslib_derivtable_list))
+        dbout:write(string.format(".SubcommandList = %s_%s_SUBCOMMAND_LIST",
+          intf:get_flattened_name(), cmd.refnode.name))
+      end
+      if (arg_list[j]) then
+        dbout:append_previous(",")
+        dbout:write(string.format(".ArgumentList = %s", arg_list[j]))
+      end
+      dbout:end_group("}")
+    end
+    dbout:end_group("};")
+    dbout:add_whitespace(1)
+  end
+end
+
+local objname = string.format("%s_TOPICID_LOOKUP", global_sym_prefix)
+local base_topicid = 1
+dbout:write(string.format("static const CFE_MissionLib_TopicId_Entry_t %s[%d] =", objname, SEDS.get_define("CFE_MISSION/MAX_TOPICID") - base_topicid))
+dbout:start_group("{")
+for tid = 1,SEDS.get_define("CFE_MISSION/MAX_TOPICID") do
+  local chain = topicid_table[tid]
+  if (chain) then
+    dbout:append_previous(",")
+    dbout:write(string.format("[%d] =", chain.tctm.TopicId - base_topicid))
+    dbout:start_group("{")
+    dbout:write(string.format(".DispatchTableId = %s_DispatchTableId_%s,", global_sym_prefix, chain.binding.reqintf.mapping_info.dispatchid))
+    dbout:write(string.format(".DispatchStartOffset = offsetof(struct %s,%s),",
+      chain.binding.reqintf.mapping_info.dispatchtype,
+      chain.binding.reqintf.name))
+    dbout:write(string.format(".InterfaceId = %s_InterfaceId_%s,", global_sym_prefix, chain.binding.reqintf.type:get_ctype_basename()))
+    dbout:write(string.format(".TopicName = \"%s\",", chain.binding.reqintf:get_qualified_name()))
+    dbout:write(string.format(".CommandList = %s_COMMANDS",chain.binding.reqintf:get_flattened_name()))
+    dbout:end_group("}")
+  end
+end
+dbout:end_group("};")
+dbout:add_whitespace(1)
+
+dbout:section_marker("Interface Definitions")
+for _,intftype in ipairs(interface_list) do
+  if (intftype:find_first("COMMAND")) then
+    dbout:write(string.format("static const CFE_MissionLib_Command_Prototype_Entry_t %s_BASE_COMMAND_LIST[] =", intftype:get_flattened_name()))
+    dbout:start_group("{")
+    for cmd in intftype:iterate_subtree("COMMAND") do
+      dbout:append_previous(",")
+      dbout:start_group("{")
+      dbout:write(string.format(".CommandName = \"%s\",", cmd.name))
+      dbout:write(string.format(".NumArguments = %d", SEDS.count_results(cmd:iterate_subtree("ARGUMENT"))))
+      dbout:end_group("}")
+    end
+    dbout:end_group("};")
+    dbout:add_whitespace(1)
+  end
+end
+
+dbout:write(string.format("static const CFE_MissionLib_InterfaceId_Entry_t %s_INTERFACEID_LOOKUP[] =", global_sym_prefix))
+dbout:start_group("{")
+for _,intftype in ipairs(interface_list) do
+  local command_count = SEDS.count_results(intftype:iterate_subtree("COMMAND"))
+  local intfname = intftype:get_qualified_name()
+  dbout:append_previous(",")
+  dbout:start_group("{")
+  dbout:write(string.format(".NumCommands = %d,", command_count))
+  dbout:write(string.format(".InterfaceName = \"%s\",", intfname))
+  if (command_count > 0) then
+    dbout:write(string.format(".CommandList = %s,", intftype:get_flattened_name() .. "_BASE_COMMAND_LIST"))
+  end
+  -- Only include topicid lookup info on the TC/TM interfaces
+  -- this is a bit of a hack as this doesn't really belong here.
+  if (intfname == "CFE_SB/Telecommand" or intfname == "CFE_SB/Telemetry") then
+    dbout:write(string.format(".NumTopics = %d,", SEDS.get_define("CFE_MISSION/MAX_TOPICID") - base_topicid))
+    dbout:write(string.format(".TopicList = %s_TOPICID_LOOKUP,", global_sym_prefix))
+  end
+  dbout:end_group("}")
+end
+dbout:end_group("};")
+dbout:add_whitespace(1)
+
+dbout:section_marker("Instance Name Table")
+dbout:write("#define DEFINE_TGTNAME(x)       #x,")
+dbout:write(string.format("static const char * const %s_INSTANCE_LIST[] =", global_sym_prefix))
+dbout:write("{")
+dbout:write("#include \"cfe_mission_tgtnames.inc\"")
+dbout:write("    NULL")
+dbout:write("};")
+
+dbout:section_marker("Summary Object")
+dbout:write(string.format("const struct CFE_MissionLib_SoftwareBus_Interface %s_SOFTWAREBUS_INTERFACE =", global_sym_prefix))
+dbout:start_group("{")
+    dbout:write(string.format(".NumInterfaces = %d,", #interface_list))
+    dbout:write(string.format(".InterfaceList = %s_INTERFACEID_LOOKUP,", global_sym_prefix))
+    dbout:write(string.format(".InstanceList = %s_INSTANCE_LIST", global_sym_prefix))
+dbout:end_group("};")
+dbout:add_whitespace(1)
+
+SEDS.output_close(dbout)

--- a/cfecfs/missionlib/eds/85-write_commandcode_headers.lua
+++ b/cfecfs/missionlib/eds/85-write_commandcode_headers.lua
@@ -85,7 +85,7 @@ for ds in SEDS.root:iterate_children(SEDS.basenode_filter) do
     for _,sc in ipairs(ds_all_subcmds) do
       hdrout:section_marker(string.format("Command Codes for \'%s\' Interface",sc.intf.name))
       for _,cc in ipairs(sc.cmd.cc_list) do
-        hdrout:add_documentation(string.format("Command code associated with %s_t", cc.argtype:get_flattened_name()))
+        hdrout:add_documentation(string.format("Command code associated with %s", SEDS.to_ctype_typedef(cc.argtype)))
         hdrout:write(string.format("#define %-60s %s",  cc.macroname, cc.value))
       end
       hdrout:add_whitespace(1)

--- a/cfecfs/missionlib/fsw/CMakeLists.txt
+++ b/cfecfs/missionlib/fsw/CMakeLists.txt
@@ -109,20 +109,6 @@ add_custom_target(missionlib-runtime-install
         EDS_${MISSION_NAME}_runtime_shared
 )
 
-# Put the components together into a regular library
-# This adds an API interface intended for use with the CFE software bus application
-file(WRITE ${MISSION_BINARY_DIR}/inc/cfe_mission_eds_interface_parameters.h.tmp
-    "/* Generated wrapper based off the real source file location */\n"
-    "#include \"${EDS_FILE_PREFIX}_interfacedb.h\"\n"
-    "#define CFE_SOFTWAREBUS_INTERFACE  ${EDS_SYMBOL_PREFIX}_SOFTWAREBUS_INTERFACE\n"
-)
-# Update the output only if different - avoid unnecessary rebuilds
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    ${MISSION_BINARY_DIR}/inc/cfe_mission_eds_interface_parameters.h.tmp
-    ${MISSION_BINARY_DIR}/inc/cfe_mission_eds_interface_parameters.h
-)
-file(REMOVE ${MISSION_BINARY_DIR}/inc/cfe_mission_eds_interface_parameters.h.tmp)
-
 add_library(cfe_missionlib STATIC
     src/cfe_missionlib_api.c
 )

--- a/cfecfs/missionlib/fsw/inc/cfe_missionlib_runtime.h
+++ b/cfecfs/missionlib/fsw/inc/cfe_missionlib_runtime.h
@@ -34,8 +34,8 @@
 #define _CFE_MISSIONLIB_RUNTIME_H_
 
 #include "cfe_mission_eds_parameters.h"
-#include "cfe_sb_eds_typedefs.h"
-#include "cfe_hdr_eds_typedefs.h"
+#include "cfe_sb_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
 
 /*
  * This code is intended to support both versions of the header, but
@@ -69,22 +69,22 @@ extern "C"
 {
 #endif
 
-    void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                             const CFE_SB_Listener_Component_t *    Input);
-    void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *                Output,
-                                               const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
-    void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                              const CFE_SB_Publisher_Component_t *   Input);
-    void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *               Output,
-                                                const CFE_SB_SoftwareBus_PubSub_Interface_t *Input);
+    void CFE_MissionLib_MapListenerComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                             const EdsComponent_CFE_SB_Listener_t *    Input);
+    void CFE_MissionLib_UnmapListenerComponent(EdsComponent_CFE_SB_Listener_t *                Output,
+                                               const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input);
+    void CFE_MissionLib_MapPublisherComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                              const EdsComponent_CFE_SB_Publisher_t *   Input);
+    void CFE_MissionLib_UnmapPublisherComponent(EdsComponent_CFE_SB_Publisher_t *               Output,
+                                                const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input);
 
-    bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
-    bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
+    bool CFE_MissionLib_PubSub_IsListenerComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params);
+    bool CFE_MissionLib_PubSub_IsPublisherComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params);
 
-    void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params,
-                                              const CFE_HDR_Message_t *              Packet);
-    void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                          Packet,
-                                              const CFE_SB_SoftwareBus_PubSub_Interface_t *Params);
+    void CFE_MissionLib_Get_PubSub_Parameters(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params,
+                                              const EdsDataType_CFE_HDR_Message_t *     Packet);
+    void CFE_MissionLib_Set_PubSub_Parameters(EdsDataType_CFE_HDR_Message_t *                 Packet,
+                                              const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/cfecfs/missionlib/fsw/src/cfe_missionlib_runtime_default.c
+++ b/cfecfs/missionlib/fsw/src/cfe_missionlib_runtime_default.c
@@ -44,8 +44,8 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "ccsds_spacepacket_eds_typedefs.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "ccsds_spacepacket_eds_datatypes.h"
+#include "cfe_sb_eds_datatypes.h"
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_missionlib_runtime.h"
 
@@ -58,7 +58,6 @@ typedef struct
     uint16_t InstanceBase;
     uint16_t InstanceMax;
 } CFE_MissionLib_TopicId_Limits_t;
-
 
 #define CFE_MISSIONLIB_GETSET_MSGID_BITS(hdr, action, ...) CFE_MissionLib_##hdr##_##action(__VA_ARGS__)
 
@@ -124,77 +123,77 @@ typedef struct
 #endif
 
 static const CFE_MissionLib_TopicId_Limits_t CFE_MISSIONLIB_GLOBAL_TLM_LIMITS = {
-    .CheckBitsMask = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_MASK,
-    .CheckBitsValue = (CFE_MISSIONLIB_MSGID_TELEMETRY_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_BITS,
-    .TopicBase = CFE_MISSION_GLOBAL_TLM_BASE_TOPICID,
-    .TopicMax = CFE_MISSION_GLOBAL_TLM_MAX_TOPICID,
+    .CheckBitsMask =
+        (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_MASK,
+    .CheckBitsValue =
+        (CFE_MISSIONLIB_MSGID_TELEMETRY_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_BITS,
+    .TopicBase    = CFE_MISSION_GLOBAL_TLM_BASE_TOPICID,
+    .TopicMax     = CFE_MISSION_GLOBAL_TLM_MAX_TOPICID,
     .InstanceBase = 0,
-    .InstanceMax = 1
-};
+    .InstanceMax  = 1};
 
 static const CFE_MissionLib_TopicId_Limits_t CFE_MISSIONLIB_LOCAL_TLM_LIMITS = {
-    .CheckBitsMask = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
+    .CheckBitsMask  = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
     .CheckBitsValue = (CFE_MISSIONLIB_MSGID_TELEMETRY_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
-    .TopicBase = CFE_MISSION_TELEMETRY_BASE_TOPICID,
-    .TopicMax = CFE_MISSION_TELEMETRY_MAX_TOPICID,
-    .InstanceBase = 1,
-    .InstanceMax = 1 + CFE_MISSIONLIB_MSGID_SUBSYS_MASK
-};
+    .TopicBase      = CFE_MISSION_TELEMETRY_BASE_TOPICID,
+    .TopicMax       = CFE_MISSION_TELEMETRY_MAX_TOPICID,
+    .InstanceBase   = 1,
+    .InstanceMax    = 1 + CFE_MISSIONLIB_MSGID_SUBSYS_MASK};
 
 static const CFE_MissionLib_TopicId_Limits_t CFE_MISSIONLIB_GLOBAL_CMD_LIMITS = {
-    .CheckBitsMask = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_MASK,
-    .CheckBitsValue = (CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_BITS,
-    .TopicBase = CFE_MISSION_GLOBAL_CMD_BASE_TOPICID,
-    .TopicMax = CFE_MISSION_GLOBAL_CMD_MAX_TOPICID,
+    .CheckBitsMask =
+        (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_MASK,
+    .CheckBitsValue =
+        (CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT) | CFE_MISSIONLIB_MSGID_GLOBAL_BITS,
+    .TopicBase    = CFE_MISSION_GLOBAL_CMD_BASE_TOPICID,
+    .TopicMax     = CFE_MISSION_GLOBAL_CMD_MAX_TOPICID,
     .InstanceBase = 0,
-    .InstanceMax = 1
-};
+    .InstanceMax  = 1};
 
 static const CFE_MissionLib_TopicId_Limits_t CFE_MISSIONLIB_LOCAL_CMD_LIMITS = {
-    .CheckBitsMask = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
+    .CheckBitsMask  = (CFE_MISSIONLIB_MSGID_TYPE_MASK << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
     .CheckBitsValue = (CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS << CFE_MISSIONLIB_MSGID_TYPE_SHIFT),
-    .TopicBase = CFE_MISSION_TELECOMMAND_BASE_TOPICID,
-    .TopicMax = CFE_MISSION_TELECOMMAND_MAX_TOPICID,
-    .InstanceBase = 1,
-    .InstanceMax = 1 + CFE_MISSIONLIB_MSGID_SUBSYS_MASK
-};
+    .TopicBase      = CFE_MISSION_TELECOMMAND_BASE_TOPICID,
+    .TopicMax       = CFE_MISSION_TELECOMMAND_MAX_TOPICID,
+    .InstanceBase   = 1,
+    .InstanceMax    = 1 + CFE_MISSIONLIB_MSGID_SUBSYS_MASK};
 
-static inline uint32_t CFE_MissionLib_GetMsgIdApid(const CFE_SB_MsgId_t *MsgId)
+static inline uint32_t CFE_MissionLib_GetMsgIdApid(const EdsDataType_CFE_SB_MsgId_t *MsgId)
 {
     return (MsgId->Value >> CFE_MISSIONLIB_MSGID_APID_SHIFT) & CFE_MISSIONLIB_MSGID_APID_MASK;
 }
 
-static inline uint32_t CFE_MissionLib_GetMsgIdInterfaceType(const CFE_SB_MsgId_t *MsgId)
+static inline uint32_t CFE_MissionLib_GetMsgIdInterfaceType(const EdsDataType_CFE_SB_MsgId_t *MsgId)
 {
     return (MsgId->Value >> CFE_MISSIONLIB_MSGID_TYPE_SHIFT) & CFE_MISSIONLIB_MSGID_TYPE_MASK;
 }
 
-static inline void CFE_MissionLib_SetMsgIdSubsystem(CFE_SB_MsgId_t *MsgId, uint32_t Val)
+static inline void CFE_MissionLib_SetMsgIdSubsystem(EdsDataType_CFE_SB_MsgId_t *MsgId, uint32_t Val)
 {
     MsgId->Value |= (Val & CFE_MISSIONLIB_MSGID_SUBSYS_MASK) << CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT;
 }
 
-static inline uint32_t CFE_MissionLib_GetMsgIdSubsystem(const CFE_SB_MsgId_t *MsgId)
+static inline uint32_t CFE_MissionLib_GetMsgIdSubsystem(const EdsDataType_CFE_SB_MsgId_t *MsgId)
 {
     return (MsgId->Value >> CFE_MISSIONLIB_MSGID_SUBSYS_SHIFT) & CFE_MISSIONLIB_MSGID_SUBSYS_MASK;
 }
 
-static inline void CFE_MissionLib_SetMsgIdSystem(CFE_SB_MsgId_t *MsgId, uint32_t Val)
+static inline void CFE_MissionLib_SetMsgIdSystem(EdsDataType_CFE_SB_MsgId_t *MsgId, uint32_t Val)
 {
     MsgId->Value |= (Val & CFE_MISSIONLIB_MSGID_SYS_MASK) << CFE_MISSIONLIB_MSGID_SYS_SHIFT;
 }
 
-static inline uint32_t CFE_MissionLib_GetMsgIdSystem(const CFE_SB_MsgId_t *MsgId)
+static inline uint32_t CFE_MissionLib_GetMsgIdSystem(const EdsDataType_CFE_SB_MsgId_t *MsgId)
 {
     return (MsgId->Value >> CFE_MISSIONLIB_MSGID_SYS_SHIFT) & CFE_MISSIONLIB_MSGID_SYS_MASK;
 }
 
-static inline void CFE_MissionLib_SetMsgIdApid(CFE_SB_MsgId_t *MsgId, uint32_t Val)
+static inline void CFE_MissionLib_SetMsgIdApid(EdsDataType_CFE_SB_MsgId_t *MsgId, uint32_t Val)
 {
     MsgId->Value |= (Val & CFE_MISSIONLIB_MSGID_APID_MASK) << CFE_MISSIONLIB_MSGID_APID_SHIFT;
 }
 
-static inline void CFE_MissionLib_SetMsgIdInterfaceType(CFE_SB_MsgId_t *MsgId, uint32_t Val)
+static inline void CFE_MissionLib_SetMsgIdInterfaceType(EdsDataType_CFE_SB_MsgId_t *MsgId, uint32_t Val)
 {
     MsgId->Value |= (Val & CFE_MISSIONLIB_MSGID_TYPE_MASK) << CFE_MISSIONLIB_MSGID_TYPE_SHIFT;
 }
@@ -207,10 +206,10 @@ static inline void CFE_MissionLib_SetMsgIdInterfaceType(CFE_SB_MsgId_t *MsgId, u
  * is not required to pack the bits this way, but the shifts/masks used above
  * will produce a MsgId bit pattern comparable to existing versions of CFE.
  */
-static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(CFE_SB_MsgId_t *                MsgId,
-                                                               const CCSDS_SpacePacketBasic_t *Packet)
+static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(EdsDataType_CFE_SB_MsgId_t *                MsgId,
+                                                               const EdsDataType_CCSDS_SpacePacketBasic_t *Packet)
 {
-    CFE_SB_MsgId_t ApidPart;
+    EdsDataType_CFE_SB_MsgId_t ApidPart;
 
     ApidPart.Value = Packet->CommonHdr.AppId;
     CFE_MissionLib_SetMsgIdApid(MsgId, CFE_MissionLib_GetMsgIdApid(&ApidPart));
@@ -218,10 +217,10 @@ static inline void CFE_MissionLib_SpacePacketBasic_BitsToMsgId(CFE_SB_MsgId_t * 
     CFE_MissionLib_SetMsgIdInterfaceType(MsgId, Packet->CommonHdr.SecHdrFlags);
 }
 
-static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(CCSDS_SpacePacketBasic_t *Packet,
-                                                                 const CFE_SB_MsgId_t *    MsgId)
+static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(EdsDataType_CCSDS_SpacePacketBasic_t *Packet,
+                                                                 const EdsDataType_CFE_SB_MsgId_t *    MsgId)
 {
-    CFE_SB_MsgId_t ApidPart;
+    EdsDataType_CFE_SB_MsgId_t ApidPart;
 
     ApidPart.Value = 0;
     CFE_MissionLib_SetMsgIdApid(&ApidPart, CFE_MissionLib_GetMsgIdApid(MsgId));
@@ -233,8 +232,8 @@ static inline void CFE_MissionLib_SpacePacketBasic_BitsFromMsgId(CCSDS_SpacePack
 }
 
 /* The following translations apply only for V2 (ApidQ) headers */
-static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(CFE_SB_MsgId_t *                MsgId,
-                                                               const CCSDS_SpacePacketApidQ_t *Packet)
+static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(EdsDataType_CFE_SB_MsgId_t *                MsgId,
+                                                               const EdsDataType_CCSDS_SpacePacketApidQ_t *Packet)
 {
     CFE_MissionLib_SetMsgIdApid(MsgId, Packet->CommonHdr.AppId);
     CFE_MissionLib_SetMsgIdInterfaceType(MsgId, Packet->CommonHdr.SecHdrFlags);
@@ -242,8 +241,8 @@ static inline void CFE_MissionLib_SpacePacketApidQ_BitsToMsgId(CFE_SB_MsgId_t * 
     CFE_MissionLib_SetMsgIdSubsystem(MsgId, Packet->ApidQ.SubsystemId);
 }
 
-static inline void CFE_MissionLib_SpacePacketApidQ_BitsFromMsgId(CCSDS_SpacePacketApidQ_t *Packet,
-                                                                 const CFE_SB_MsgId_t *    MsgId)
+static inline void CFE_MissionLib_SpacePacketApidQ_BitsFromMsgId(EdsDataType_CCSDS_SpacePacketApidQ_t *Packet,
+                                                                 const EdsDataType_CFE_SB_MsgId_t *    MsgId)
 {
     Packet->CommonHdr.VersionId   = 1;
     Packet->CommonHdr.AppId       = CFE_MissionLib_GetMsgIdApid(MsgId);
@@ -252,7 +251,9 @@ static inline void CFE_MissionLib_SpacePacketApidQ_BitsFromMsgId(CCSDS_SpacePack
     Packet->ApidQ.SubsystemId     = CFE_MissionLib_GetMsgIdSubsystem(MsgId);
 }
 
-static bool CFE_MissionLib_TryMapping(CFE_SB_SoftwareBus_PubSub_Interface_t *Output, const CFE_MissionLib_TopicId_Limits_t *Limits, uint16_t InstanceIdx, uint16_t TopicIdx)
+static bool CFE_MissionLib_TryMapping(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                      const CFE_MissionLib_TopicId_Limits_t *Limits, uint16_t InstanceIdx,
+                                      uint16_t TopicIdx)
 {
     InstanceIdx -= Limits->InstanceBase;
     TopicIdx -= Limits->TopicBase;
@@ -271,9 +272,11 @@ static bool CFE_MissionLib_TryMapping(CFE_SB_SoftwareBus_PubSub_Interface_t *Out
     return true;
 }
 
-static bool CFE_MissionLib_TryUnmapping(uint16_t *InstanceIdOut, uint16_t *TopicIdOut, const CFE_MissionLib_TopicId_Limits_t *Limits,  const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+static bool CFE_MissionLib_TryUnmapping(uint16_t *InstanceIdOut, uint16_t *TopicIdOut,
+                                        const CFE_MissionLib_TopicId_Limits_t *         Limits,
+                                        const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input)
 {
-    CFE_SB_MsgId_t TempMsgId;
+    EdsDataType_CFE_SB_MsgId_t TempMsgId;
 
     if ((Input->MsgId.Value & Limits->CheckBitsMask) != Limits->CheckBitsValue)
     {
@@ -285,74 +288,80 @@ static bool CFE_MissionLib_TryUnmapping(uint16_t *InstanceIdOut, uint16_t *Topic
     TempMsgId.Value ^= Limits->CheckBitsValue;
 
     *InstanceIdOut = CFE_MissionLib_GetMsgIdSubsystem(&TempMsgId) + Limits->InstanceBase;
-    *TopicIdOut = CFE_MissionLib_GetMsgIdApid(&TempMsgId) + Limits->TopicBase;
+    *TopicIdOut    = CFE_MissionLib_GetMsgIdApid(&TempMsgId) + Limits->TopicBase;
 
     return true;
 }
 
-void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                         const CFE_SB_Listener_Component_t *    Input)
+void CFE_MissionLib_MapListenerComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                         const EdsComponent_CFE_SB_Listener_t *    Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (!CFE_MissionLib_TryMapping (Output, &CFE_MISSIONLIB_LOCAL_CMD_LIMITS, Input->Telecommand.InstanceNumber, Input->Telecommand.TopicId))
+    if (!CFE_MissionLib_TryMapping(Output, &CFE_MISSIONLIB_LOCAL_CMD_LIMITS, Input->Telecommand.InstanceNumber,
+                                   Input->Telecommand.TopicId))
     {
-        CFE_MissionLib_TryMapping (Output, &CFE_MISSIONLIB_GLOBAL_CMD_LIMITS, 0, Input->Telecommand.TopicId);
+        CFE_MissionLib_TryMapping(Output, &CFE_MISSIONLIB_GLOBAL_CMD_LIMITS, 0, Input->Telecommand.TopicId);
     }
 }
 
-void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *                Output,
-                                           const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapListenerComponent(EdsComponent_CFE_SB_Listener_t *                Output,
+                                           const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (!CFE_MissionLib_TryUnmapping (&Output->Telecommand.InstanceNumber, &Output->Telecommand.TopicId, &CFE_MISSIONLIB_GLOBAL_CMD_LIMITS, Input))
+    if (!CFE_MissionLib_TryUnmapping(&Output->Telecommand.InstanceNumber, &Output->Telecommand.TopicId,
+                                     &CFE_MISSIONLIB_GLOBAL_CMD_LIMITS, Input))
     {
-        CFE_MissionLib_TryUnmapping (&Output->Telecommand.InstanceNumber, &Output->Telecommand.TopicId, &CFE_MISSIONLIB_LOCAL_CMD_LIMITS, Input);
+        CFE_MissionLib_TryUnmapping(&Output->Telecommand.InstanceNumber, &Output->Telecommand.TopicId,
+                                    &CFE_MISSIONLIB_LOCAL_CMD_LIMITS, Input);
     }
 }
 
-bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+bool CFE_MissionLib_PubSub_IsListenerComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
     return (CFE_MissionLib_GetMsgIdInterfaceType(&Params->MsgId) == CFE_MISSIONLIB_MSGID_TELECOMMAND_BITS);
 }
 
-void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                          const CFE_SB_Publisher_Component_t *   Input)
+void CFE_MissionLib_MapPublisherComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                          const EdsComponent_CFE_SB_Publisher_t *   Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (!CFE_MissionLib_TryMapping (Output, &CFE_MISSIONLIB_LOCAL_TLM_LIMITS, Input->Telemetry.InstanceNumber, Input->Telemetry.TopicId))
+    if (!CFE_MissionLib_TryMapping(Output, &CFE_MISSIONLIB_LOCAL_TLM_LIMITS, Input->Telemetry.InstanceNumber,
+                                   Input->Telemetry.TopicId))
     {
-        CFE_MissionLib_TryMapping (Output, &CFE_MISSIONLIB_GLOBAL_TLM_LIMITS, 0, Input->Telemetry.TopicId);
+        CFE_MissionLib_TryMapping(Output, &CFE_MISSIONLIB_GLOBAL_TLM_LIMITS, 0, Input->Telemetry.TopicId);
     }
 }
 
-void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *               Output,
-                                            const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapPublisherComponent(EdsComponent_CFE_SB_Publisher_t *               Output,
+                                            const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input)
 {
     memset(Output, 0, sizeof(*Output));
 
-    if (!CFE_MissionLib_TryUnmapping (&Output->Telemetry.InstanceNumber, &Output->Telemetry.TopicId, &CFE_MISSIONLIB_LOCAL_TLM_LIMITS, Input))
+    if (!CFE_MissionLib_TryUnmapping(&Output->Telemetry.InstanceNumber, &Output->Telemetry.TopicId,
+                                     &CFE_MISSIONLIB_LOCAL_TLM_LIMITS, Input))
     {
-        CFE_MissionLib_TryUnmapping (&Output->Telemetry.InstanceNumber, &Output->Telemetry.TopicId, &CFE_MISSIONLIB_GLOBAL_TLM_LIMITS, Input);
+        CFE_MissionLib_TryUnmapping(&Output->Telemetry.InstanceNumber, &Output->Telemetry.TopicId,
+                                    &CFE_MISSIONLIB_GLOBAL_TLM_LIMITS, Input);
     }
 }
 
-bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+bool CFE_MissionLib_PubSub_IsPublisherComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
     return (CFE_MissionLib_GetMsgIdInterfaceType(&Params->MsgId) == CFE_MISSIONLIB_MSGID_TELEMETRY_BITS);
 }
 
-void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params,
-                                          const CFE_HDR_Message_t *              Packet)
+void CFE_MissionLib_Get_PubSub_Parameters(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params,
+                                          const EdsDataType_CFE_HDR_Message_t *     Packet)
 {
     memset(Params, 0, sizeof(*Params));
     CFE_MISSIONLIB_GET_MSGID_BITS(CFE_MISSION_MSG_HEADER_TYPE, &Params->MsgId, &Packet->CCSDS);
 }
 
-void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                          Packet,
-                                          const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+void CFE_MissionLib_Set_PubSub_Parameters(EdsDataType_CFE_HDR_Message_t *                 Packet,
+                                          const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
     CFE_MISSIONLIB_SET_MSGID_BITS(CFE_MISSION_MSG_HEADER_TYPE, &Packet->CCSDS, &Params->MsgId);
 }

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_api_stubs.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_api_stubs.c
@@ -27,19 +27,19 @@
 #include "cfe_missionlib_api.h"
 #include "utgenstub.h"
 
-extern void UT_DefaultHandler_CFE_MissionLib_FindCommandByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_FindInterfaceByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_FindTopicByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetArgumentType(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetCommandName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetIndicationInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetInstanceName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetInstanceNumber(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetInterfaceInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetInterfaceName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetSubcommandOffset(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetTopicInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_GetTopicName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_FindCommandByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_FindInterfaceByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_FindTopicByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetArgumentType(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetCommandName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetIndicationInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetInstanceName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetInstanceNumber(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetInterfaceInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetInterfaceName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetSubcommandOffset(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetTopicInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_GetTopicName(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
  * ----------------------------------------------------

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_handlers.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_handlers.c
@@ -71,8 +71,8 @@ void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *UserObj, UT_Ent
                                                            const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultZeroOutput(
-        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *),
-        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", EdsInterface_CFE_SB_SoftwareBus_PubSub_t *),
+        sizeof(EdsInterface_CFE_SB_SoftwareBus_PubSub_t));
 }
 
 /*------------------------------------------------------------
@@ -83,9 +83,9 @@ void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *UserObj, UT_Ent
 void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *UserObj, UT_EntryKey_t FuncKey,
                                                              const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
-                                          UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Listener_Component_t *),
-                                          sizeof(CFE_SB_Listener_Component_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", EdsComponent_CFE_SB_Listener_t *),
+        sizeof(EdsComponent_CFE_SB_Listener_t));
 }
 
 /*------------------------------------------------------------
@@ -97,8 +97,8 @@ void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *UserObj, UT_En
                                                             const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultZeroOutput(
-        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_SoftwareBus_PubSub_Interface_t *),
-        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", EdsInterface_CFE_SB_SoftwareBus_PubSub_t *),
+        sizeof(EdsInterface_CFE_SB_SoftwareBus_PubSub_t));
 }
 
 /*------------------------------------------------------------
@@ -109,9 +109,9 @@ void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *UserObj, UT_En
 void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *UserObj, UT_EntryKey_t FuncKey,
                                                               const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
-                                          UT_Hook_GetArgValueByName(Context, "Output", CFE_SB_Publisher_Component_t *),
-                                          sizeof(CFE_SB_Publisher_Component_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Output", EdsComponent_CFE_SB_Publisher_t *),
+        sizeof(EdsComponent_CFE_SB_Publisher_t));
 }
 
 /*------------------------------------------------------------
@@ -123,8 +123,8 @@ void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *UserObj, UT_En
                                                             const UT_StubContext_t *Context)
 {
     CFE_MissionLib_Stub_DefaultZeroOutput(
-        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Params", CFE_SB_SoftwareBus_PubSub_Interface_t *),
-        sizeof(CFE_SB_SoftwareBus_PubSub_Interface_t));
+        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Params", EdsInterface_CFE_SB_SoftwareBus_PubSub_t *),
+        sizeof(EdsInterface_CFE_SB_SoftwareBus_PubSub_t));
 }
 
 /*------------------------------------------------------------
@@ -135,6 +135,7 @@ void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *UserObj, UT_En
 void UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters(void *UserObj, UT_EntryKey_t FuncKey,
                                                             const UT_StubContext_t *Context)
 {
-    CFE_MissionLib_Stub_DefaultZeroOutput(
-        FuncKey, Context, UT_Hook_GetArgValueByName(Context, "Packet", CFE_HDR_Message_t *), sizeof(CFE_HDR_Message_t));
+    CFE_MissionLib_Stub_DefaultZeroOutput(FuncKey, Context,
+                                          UT_Hook_GetArgValueByName(Context, "Packet", EdsDataType_CFE_HDR_Message_t *),
+                                          sizeof(EdsDataType_CFE_HDR_Message_t));
 }

--- a/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_stubs.c
+++ b/cfecfs/missionlib/fsw/ut-stubs/cfe_missionlib_runtime_stubs.c
@@ -27,27 +27,25 @@
 #include "cfe_missionlib_runtime.h"
 #include "utgenstub.h"
 
-extern void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_PubSub_IsListenerComponent(void *, UT_EntryKey_t,
-                                                                        const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_PubSub_IsPublisherComponent(void *, UT_EntryKey_t,
-                                                                         const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_MapListenerComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_PubSub_IsListenerComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_PubSub_IsPublisherComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
  * ----------------------------------------------------
  * Generated stub function for CFE_MissionLib_Get_PubSub_Parameters()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t *Params,
-                                          const CFE_HDR_Message_t *              Packet)
+void CFE_MissionLib_Get_PubSub_Parameters(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params,
+                                          const EdsDataType_CFE_HDR_Message_t *     Packet)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_Get_PubSub_Parameters, CFE_SB_SoftwareBus_PubSub_Interface_t *, Params);
-    UT_GenStub_AddParam(CFE_MissionLib_Get_PubSub_Parameters, const CFE_HDR_Message_t *, Packet);
+    UT_GenStub_AddParam(CFE_MissionLib_Get_PubSub_Parameters, EdsInterface_CFE_SB_SoftwareBus_PubSub_t *, Params);
+    UT_GenStub_AddParam(CFE_MissionLib_Get_PubSub_Parameters, const EdsDataType_CFE_HDR_Message_t *, Packet);
 
     UT_GenStub_Execute(CFE_MissionLib_Get_PubSub_Parameters, Basic,
                        UT_DefaultHandler_CFE_MissionLib_Get_PubSub_Parameters);
@@ -58,11 +56,11 @@ void CFE_MissionLib_Get_PubSub_Parameters(CFE_SB_SoftwareBus_PubSub_Interface_t 
  * Generated stub function for CFE_MissionLib_MapListenerComponent()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                         const CFE_SB_Listener_Component_t *    Input)
+void CFE_MissionLib_MapListenerComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                         const EdsComponent_CFE_SB_Listener_t *    Input)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_MapListenerComponent, CFE_SB_SoftwareBus_PubSub_Interface_t *, Output);
-    UT_GenStub_AddParam(CFE_MissionLib_MapListenerComponent, const CFE_SB_Listener_Component_t *, Input);
+    UT_GenStub_AddParam(CFE_MissionLib_MapListenerComponent, EdsInterface_CFE_SB_SoftwareBus_PubSub_t *, Output);
+    UT_GenStub_AddParam(CFE_MissionLib_MapListenerComponent, const EdsComponent_CFE_SB_Listener_t *, Input);
 
     UT_GenStub_Execute(CFE_MissionLib_MapListenerComponent, Basic,
                        UT_DefaultHandler_CFE_MissionLib_MapListenerComponent);
@@ -73,11 +71,11 @@ void CFE_MissionLib_MapListenerComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *
  * Generated stub function for CFE_MissionLib_MapPublisherComponent()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t *Output,
-                                          const CFE_SB_Publisher_Component_t *   Input)
+void CFE_MissionLib_MapPublisherComponent(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Output,
+                                          const EdsComponent_CFE_SB_Publisher_t *   Input)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_MapPublisherComponent, CFE_SB_SoftwareBus_PubSub_Interface_t *, Output);
-    UT_GenStub_AddParam(CFE_MissionLib_MapPublisherComponent, const CFE_SB_Publisher_Component_t *, Input);
+    UT_GenStub_AddParam(CFE_MissionLib_MapPublisherComponent, EdsInterface_CFE_SB_SoftwareBus_PubSub_t *, Output);
+    UT_GenStub_AddParam(CFE_MissionLib_MapPublisherComponent, const EdsComponent_CFE_SB_Publisher_t *, Input);
 
     UT_GenStub_Execute(CFE_MissionLib_MapPublisherComponent, Basic,
                        UT_DefaultHandler_CFE_MissionLib_MapPublisherComponent);
@@ -88,11 +86,11 @@ void CFE_MissionLib_MapPublisherComponent(CFE_SB_SoftwareBus_PubSub_Interface_t 
  * Generated stub function for CFE_MissionLib_PubSub_IsListenerComponent()
  * ----------------------------------------------------
  */
-bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+bool CFE_MissionLib_PubSub_IsListenerComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
     UT_GenStub_SetupReturnBuffer(CFE_MissionLib_PubSub_IsListenerComponent, bool);
 
-    UT_GenStub_AddParam(CFE_MissionLib_PubSub_IsListenerComponent, const CFE_SB_SoftwareBus_PubSub_Interface_t *,
+    UT_GenStub_AddParam(CFE_MissionLib_PubSub_IsListenerComponent, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *,
                         Params);
 
     UT_GenStub_Execute(CFE_MissionLib_PubSub_IsListenerComponent, Basic,
@@ -106,11 +104,11 @@ bool CFE_MissionLib_PubSub_IsListenerComponent(const CFE_SB_SoftwareBus_PubSub_I
  * Generated stub function for CFE_MissionLib_PubSub_IsPublisherComponent()
  * ----------------------------------------------------
  */
-bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+bool CFE_MissionLib_PubSub_IsPublisherComponent(const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
     UT_GenStub_SetupReturnBuffer(CFE_MissionLib_PubSub_IsPublisherComponent, bool);
 
-    UT_GenStub_AddParam(CFE_MissionLib_PubSub_IsPublisherComponent, const CFE_SB_SoftwareBus_PubSub_Interface_t *,
+    UT_GenStub_AddParam(CFE_MissionLib_PubSub_IsPublisherComponent, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *,
                         Params);
 
     UT_GenStub_Execute(CFE_MissionLib_PubSub_IsPublisherComponent, Basic,
@@ -124,11 +122,11 @@ bool CFE_MissionLib_PubSub_IsPublisherComponent(const CFE_SB_SoftwareBus_PubSub_
  * Generated stub function for CFE_MissionLib_Set_PubSub_Parameters()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                          Packet,
-                                          const CFE_SB_SoftwareBus_PubSub_Interface_t *Params)
+void CFE_MissionLib_Set_PubSub_Parameters(EdsDataType_CFE_HDR_Message_t *                 Packet,
+                                          const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Params)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_Set_PubSub_Parameters, CFE_HDR_Message_t *, Packet);
-    UT_GenStub_AddParam(CFE_MissionLib_Set_PubSub_Parameters, const CFE_SB_SoftwareBus_PubSub_Interface_t *, Params);
+    UT_GenStub_AddParam(CFE_MissionLib_Set_PubSub_Parameters, EdsDataType_CFE_HDR_Message_t *, Packet);
+    UT_GenStub_AddParam(CFE_MissionLib_Set_PubSub_Parameters, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *, Params);
 
     UT_GenStub_Execute(CFE_MissionLib_Set_PubSub_Parameters, Basic,
                        UT_DefaultHandler_CFE_MissionLib_Set_PubSub_Parameters);
@@ -139,11 +137,11 @@ void CFE_MissionLib_Set_PubSub_Parameters(CFE_HDR_Message_t *                   
  * Generated stub function for CFE_MissionLib_UnmapListenerComponent()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *                Output,
-                                           const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapListenerComponent(EdsComponent_CFE_SB_Listener_t *                Output,
+                                           const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_UnmapListenerComponent, CFE_SB_Listener_Component_t *, Output);
-    UT_GenStub_AddParam(CFE_MissionLib_UnmapListenerComponent, const CFE_SB_SoftwareBus_PubSub_Interface_t *, Input);
+    UT_GenStub_AddParam(CFE_MissionLib_UnmapListenerComponent, EdsComponent_CFE_SB_Listener_t *, Output);
+    UT_GenStub_AddParam(CFE_MissionLib_UnmapListenerComponent, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *, Input);
 
     UT_GenStub_Execute(CFE_MissionLib_UnmapListenerComponent, Basic,
                        UT_DefaultHandler_CFE_MissionLib_UnmapListenerComponent);
@@ -154,11 +152,12 @@ void CFE_MissionLib_UnmapListenerComponent(CFE_SB_Listener_Component_t *        
  * Generated stub function for CFE_MissionLib_UnmapPublisherComponent()
  * ----------------------------------------------------
  */
-void CFE_MissionLib_UnmapPublisherComponent(CFE_SB_Publisher_Component_t *               Output,
-                                            const CFE_SB_SoftwareBus_PubSub_Interface_t *Input)
+void CFE_MissionLib_UnmapPublisherComponent(EdsComponent_CFE_SB_Publisher_t *               Output,
+                                            const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *Input)
 {
-    UT_GenStub_AddParam(CFE_MissionLib_UnmapPublisherComponent, CFE_SB_Publisher_Component_t *, Output);
-    UT_GenStub_AddParam(CFE_MissionLib_UnmapPublisherComponent, const CFE_SB_SoftwareBus_PubSub_Interface_t *, Input);
+    UT_GenStub_AddParam(CFE_MissionLib_UnmapPublisherComponent, EdsComponent_CFE_SB_Publisher_t *, Output);
+    UT_GenStub_AddParam(CFE_MissionLib_UnmapPublisherComponent, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *,
+                        Input);
 
     UT_GenStub_Execute(CFE_MissionLib_UnmapPublisherComponent, Basic,
                        UT_DefaultHandler_CFE_MissionLib_UnmapPublisherComponent);

--- a/cfecfs/missionlib/lua/inc/cfe_missionlib_lua_softwarebus.h
+++ b/cfecfs/missionlib/lua/inc/cfe_missionlib_lua_softwarebus.h
@@ -32,7 +32,7 @@
 
 #include <lua.h>
 #include "cfe_missionlib_api.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "cfe_sb_eds_datatypes.h"
 
 typedef struct
 {
@@ -47,7 +47,7 @@ typedef struct
 
 void CFE_MissionLib_Lua_SoftwareBus_Attach(lua_State *lua, const CFE_MissionLib_SoftwareBus_Interface_t *IntfDB);
 
-void CFE_MissionLib_Lua_MapPubSubParams(CFE_SB_SoftwareBus_PubSub_Interface_t *PubSub, const CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj);
-void CFE_MissionLib_Lua_UnmapPubSubParams(CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj, const CFE_SB_SoftwareBus_PubSub_Interface_t *PubSub);
+void CFE_MissionLib_Lua_MapPubSubParams(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *PubSub, const CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj);
+void CFE_MissionLib_Lua_UnmapPubSubParams(CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *PubSub);
 
 #endif  /* _CFE_MISSIONLIB_LUA_SOFTWAREBUS_H_ */

--- a/cfecfs/missionlib/lua/src/cfe_missionlib_lua_softwarebus.c
+++ b/cfecfs/missionlib/lua/src/cfe_missionlib_lua_softwarebus.c
@@ -53,21 +53,21 @@
 
 static const char CFE_MISSIONLIB_INTFDB_KEY;
 
-void CFE_MissionLib_Lua_MapPubSubParams(CFE_SB_SoftwareBus_PubSub_Interface_t *PubSub, const CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj)
+void CFE_MissionLib_Lua_MapPubSubParams(EdsInterface_CFE_SB_SoftwareBus_PubSub_t *PubSub, const CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj)
 {
     switch (IntfObj->IntfId)
     {
-    case CFE_SB_Telecommand_Interface_ID:
+    case EDS_INTERFACE_ID(CFE_SB_Telecommand):
     {
-        CFE_SB_Listener_Component_t Params;
+        EdsComponent_CFE_SB_Listener_t Params;
         Params.Telecommand.InstanceNumber = IntfObj->InstanceNumber;
         Params.Telecommand.TopicId = IntfObj->TopicId;
         CFE_MissionLib_MapListenerComponent(PubSub, &Params);
         break;
     }
-    case CFE_SB_Telemetry_Interface_ID:
+    case EDS_INTERFACE_ID(CFE_SB_Telemetry):
     {
-        CFE_SB_Publisher_Component_t Params;
+        EdsComponent_CFE_SB_Publisher_t Params;
         Params.Telemetry.InstanceNumber = IntfObj->InstanceNumber;
         Params.Telemetry.TopicId = IntfObj->TopicId;
         CFE_MissionLib_MapPublisherComponent(PubSub, &Params);
@@ -81,21 +81,21 @@ void CFE_MissionLib_Lua_MapPubSubParams(CFE_SB_SoftwareBus_PubSub_Interface_t *P
     }
 }
 
-void CFE_MissionLib_Lua_UnmapPubSubParams(CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj, const CFE_SB_SoftwareBus_PubSub_Interface_t *PubSub)
+void CFE_MissionLib_Lua_UnmapPubSubParams(CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t *PubSub)
 {
     switch(IntfObj->IntfId)
     {
-    case CFE_SB_Telecommand_Interface_ID:
+    case EDS_INTERFACE_ID(CFE_SB_Telecommand):
     {
-        CFE_SB_Listener_Component_t Result;
+        EdsComponent_CFE_SB_Listener_t Result;
         CFE_MissionLib_UnmapListenerComponent(&Result, PubSub);
         IntfObj->TopicId = Result.Telecommand.TopicId;
         IntfObj->InstanceNumber = Result.Telecommand.InstanceNumber;
         break;
     }
-    case CFE_SB_Telemetry_Interface_ID:
+    case EDS_INTERFACE_ID(CFE_SB_Telemetry):
     {
-        CFE_SB_Publisher_Component_t Result;
+        EdsComponent_CFE_SB_Publisher_t Result;
         CFE_MissionLib_UnmapPublisherComponent(&Result, PubSub);
         IntfObj->TopicId = Result.Telemetry.TopicId;
         IntfObj->InstanceNumber = Result.Telemetry.InstanceNumber;
@@ -274,7 +274,7 @@ static int CFE_MissionLib_Lua_InterfaceObjectGetProperty(lua_State *lua)
         }
         else if (strcmp(PropName, "MsgId") == 0)
         {
-            CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+            EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
             CFE_MissionLib_Lua_MapPubSubParams(&PubSub, IntfObj);
             lua_pushinteger(lua, PubSub.MsgId.Value);
             retval = 1;
@@ -376,7 +376,7 @@ static int CFE_MissionLib_Lua_NewMessage(lua_State *lua)
     const char *CommandName = luaL_optstring(lua, 2, NULL);
     EdsLib_DataTypeDB_DerivedTypeInfo_t DerivInfo;
     EdsLib_LuaBinding_DescriptorObject_t *ObjectUserData;
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
     EdsLib_Id_t PossibleId;
     uint16_t DerivIdx;
     int32_t Status;
@@ -435,7 +435,7 @@ static int CFE_MissionLib_Lua_IdentifyMessage(lua_State *lua)
     const char *IndicationName = luaL_optstring(lua, 2, "indication");
     EdsLib_Binding_DescriptorObject_t *ObjectUserData;
     CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj;
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
     EdsLib_DataTypeDB_DerivedTypeInfo_t DerivInfo;
     CFE_MissionLib_InterfaceInfo_t IntfInfo;
     EdsLib_Id_t EdsId;

--- a/cfecfs/missionlib/python/inc/cfe_missionlib_python.h
+++ b/cfecfs/missionlib/python/inc/cfe_missionlib_python.h
@@ -99,6 +99,6 @@ const CFE_MissionLib_SoftwareBus_Interface_t *CFE_MissionLib_Python_Database_Get
  *
  * This is a convenience wrapper that performs type checking and conversions
  */
-//PyTypeObject *CFE_MissionLib_Python_TopicEntry_GetFromMsgId(PyObject *dbobj, const CFE_SB_SoftwareBus_PubSub_Interface_t Params);
+//PyTypeObject *CFE_MissionLib_Python_TopicEntry_GetFromMsgId(PyObject *dbobj, const EdsInterface_CFE_SB_SoftwareBus_PubSub_t Params);
 
 #endif /* TOOLS_EDS_CFECFS_MISSIONLIB_PYTHON_INC_CFE_MISSIONLIB_PYTHON_H_ */

--- a/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
+++ b/cfecfs/missionlib/python/src/cfe_missionlib_python_database.c
@@ -39,9 +39,9 @@
 #include "cfe_missionlib_runtime.h"
 
 #include "cfe_mission_eds_interface_parameters.h"
-#include "ccsds_spacepacket_eds_typedefs.h"
+#include "ccsds_spacepacket_eds_datatypes.h"
 #include "ccsds_spacepacket_eds_defines.h"
-#include "cfe_sb_eds_typedefs.h"
+#include "cfe_sb_eds_datatypes.h"
 #include "edslib_binding_objects.h"
 
 PyObject *CFE_MissionLib_Python_DatabaseCache = NULL;
@@ -382,11 +382,11 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
 
     Py_ssize_t BytesSize;
     char *NetworkBuffer;
-    CFE_HDR_Message_Buffer_t LocalBuffer;
+    CFE_MSG_Message_Buffer_t LocalBuffer;
 
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSubParams;
-    CFE_SB_Publisher_Component_t PublisherParams;
-    CFE_SB_Listener_Component_t ListenerParams;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSubParams;
+    EdsComponent_CFE_SB_Publisher_t PublisherParams;
+    EdsComponent_CFE_SB_Listener_t ListenerParams;
 
     EdsLib_Id_t EdsId;
     uint16_t TopicId;
@@ -438,7 +438,7 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
             CFE_MissionLib_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
             TopicId = PublisherParams.Telemetry.TopicId;
 
-            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telemetry_Interface_ID,
+            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, EdsInterface_CFE_SB_Telemetry_ID,
                     PublisherParams.Telemetry.TopicId, 1, 1, &EdsId);
         }
         else if (CFE_MissionLib_PubSub_IsListenerComponent(&PubSubParams))
@@ -446,7 +446,7 @@ static PyObject *CFE_MissionLib_Python_DecodeEdsId(PyObject *obj, PyObject *args
             CFE_MissionLib_UnmapListenerComponent(&ListenerParams, &PubSubParams);
             TopicId = ListenerParams.Telecommand.TopicId;
 
-            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, CFE_SB_Telecommand_Interface_ID,
+            Status = CFE_MissionLib_GetArgumentType(IntfDb->IntfDb, EdsInterface_CFE_SB_Telecommand_ID,
                     ListenerParams.Telecommand.TopicId, 1, 1, &EdsId);
         }
         else
@@ -482,10 +482,10 @@ static PyObject *  CFE_MissionLib_Python_Set_PubSub(PyObject *obj, PyObject *arg
     EdsLib_Python_ObjectBase_t *Python_Packet;
     EdsLib_Python_Buffer_t *StorageBuffer;
     EdsLib_Binding_Buffer_Content_t edsbuf;
-    CFE_HDR_Message_t *Packet;
+    CFE_MSG_Message_t *Packet;
 
-    CFE_SB_Listener_Component_t Params;
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+    EdsComponent_CFE_SB_Listener_t Params;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
 
     if (!PyArg_UnpackTuple(args, "DecodeEdsId", 3, 3, &arg1, &arg2, &arg3))
     {
@@ -529,7 +529,7 @@ static PyObject *  CFE_MissionLib_Python_Set_PubSub(PyObject *obj, PyObject *arg
         Python_Packet = (EdsLib_Python_ObjectBase_t *) arg3;
         StorageBuffer = Python_Packet->StorageBuf;
         edsbuf = StorageBuffer->edsbuf;
-        Packet = (CFE_HDR_Message_t *) edsbuf.Data;
+        Packet = (CFE_MSG_Message_t *) edsbuf.Data;
 
         CFE_MissionLib_MapListenerComponent(&PubSub, &Params);
         CFE_MissionLib_Set_PubSub_Parameters(Packet, &PubSub);

--- a/cfecfs/scriptengine/fsw/src/scriptengine.c
+++ b/cfecfs/scriptengine/fsw/src/scriptengine.c
@@ -163,7 +163,7 @@ static int SCRIPTENGINE_WaitFor(lua_State *lua)
     CFE_MissionLib_Lua_Interface_Userdata_t *IntfObj = luaL_checkudata(lua, 1, "CFE_MissionLib_Lua_Interface");
     CFE_SB_PipeId_t *PipeObj = luaL_checkudata(lua, 2, "CFE_SB_PipeId");
     lua_Integer timeout = luaL_optinteger(lua, 3, 1000);
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
     CFE_SB_Buffer_t *BufPtr;
     CFE_MSG_Size_t MsgSize;
     EdsLib_Binding_DescriptorObject_t *ObjectUserData;

--- a/cfecfs/testexecutive/modules/ci_to_lab_interface.c
+++ b/cfecfs/testexecutive/modules/ci_to_lab_interface.c
@@ -51,7 +51,7 @@
 #include "cfe_missionlib_lua_softwarebus.h"
 
 #include "testexec.h"
-#include "to_lab_eds_typedefs.h"
+#include "to_lab_eds_datatypes.h"
 
 #define TO_LAB_BASE_PORT        1235
 #define CI_LAB_BASE_PORT        1234
@@ -61,7 +61,7 @@
 
 typedef struct
 {
-    CFE_SB_SoftwareBus_PubSub_Interface_t TargetApp;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t TargetApp;
     struct sockaddr_in LocalAddr;
     struct sockaddr_in TargetAddr;
     struct timespec InterPacketDelay;

--- a/cfecfs/testexecutive/src/testctrl.c
+++ b/cfecfs/testexecutive/src/testctrl.c
@@ -40,7 +40,7 @@
 #include "cfe_missionlib_runtime.h"
 #include "cfe_missionlib_api.h"
 #include "cfe_missionlib_lua_softwarebus.h"
-#include "ccsds_spacepacket_eds_typedefs.h"
+#include "ccsds_spacepacket_eds_datatypes.h"
 
 
 /*
@@ -318,5 +318,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-
-

--- a/cfecfs/util/cmdUtil.c
+++ b/cfecfs/util/cmdUtil.c
@@ -63,7 +63,7 @@ typedef int socklen_t;
 #include "edslib_displaydb.h"
 #include "cfe_missionlib_api.h"
 #include "cfe_missionlib_runtime.h"
-#include "cfe_hdr_eds_typedefs.h"
+#include "cfe_hdr_eds_datatypes.h"
 
 const char DEFAULT_COMPONENT[] = "Application";
 
@@ -177,9 +177,9 @@ typedef struct {
 
     EdsLib_Id_t IntfArg;
     EdsLib_Id_t ActualArg;
-    CFE_SB_Listener_Component_t Params;
+    EdsComponent_CFE_SB_Listener_t Params;
     CFE_MissionLib_InterfaceInfo_t IntfInfo;
-    CFE_SB_SoftwareBus_PubSub_Interface_t PubSub;
+    EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSub;
     uint16_t CommandCodeConstrIdx;
     EdsLib_DataTypeDB_EntityInfo_t CommandCodeInfo;
     EdsLib_DataTypeDB_TypeInfo_t EdsHeaderInfo;
@@ -189,8 +189,8 @@ typedef struct {
 } CommandData_t;
 
 
-CFE_HDR_CommandHeader_Buffer_t CommandBuffer;
-static CFE_HDR_CommandHeader_PackedBuffer_t PackedCommand;
+EdsNativeBuffer_CFE_HDR_CommandHeader_t CommandBuffer;
+static EdsPackedBuffer_CFE_HDR_CommandHeader_t PackedCommand;
 
 /*
 ** Declare the global command data
@@ -453,7 +453,7 @@ int main(int argc, char *argv[]) {
         strcpy(CommandData.CmdName, Separator + 1);
     }
 
-    EdsRc = CFE_MissionLib_FindTopicByName(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telecommand_Interface_ID,
+    EdsRc = CFE_MissionLib_FindTopicByName(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telecommand),
             CommandData.DestIntf, &CommandData.Params.Telecommand.TopicId);
     if (EdsRc != CFE_MISSIONLIB_SUCCESS)
     {
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
             memmove(Separator + sizeof(DEFAULT_COMPONENT), Separator, 1 + FullLen - (Separator - CommandData.DestIntf));
             memcpy(Separator+1, DEFAULT_COMPONENT, sizeof(DEFAULT_COMPONENT) - 1);
             Separator[0] = '/';
-            EdsRc = CFE_MissionLib_FindTopicByName(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telecommand_Interface_ID,
+            EdsRc = CFE_MissionLib_FindTopicByName(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telecommand),
                     CommandData.DestIntf, &CommandData.Params.Telecommand.TopicId);
         }
     }
@@ -483,13 +483,13 @@ int main(int argc, char *argv[]) {
         if (CommandData.GotUsageReq)
         {
             printf("EDS-defined Telecommand Interfaces:\n");
-            CFE_MissionLib_EnumerateTopics(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telecommand_Interface_ID, Enumerate_Topics_Usage_Callback, NULL);
+            CFE_MissionLib_EnumerateTopics(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telecommand), Enumerate_Topics_Usage_Callback, NULL);
             printf("\n");
         }
         return EXIT_FAILURE;
     }
 
-    EdsRc = CFE_MissionLib_GetInterfaceInfo(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telecommand_Interface_ID, &CommandData.IntfInfo);
+    EdsRc = CFE_MissionLib_GetInterfaceInfo(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telecommand), &CommandData.IntfInfo);
     if (EdsRc != CFE_MISSIONLIB_SUCCESS)
     {
         fprintf(stderr,"Cannot lookup interface info for: '%s'\n", CommandData.DestIntf);
@@ -506,7 +506,7 @@ int main(int argc, char *argv[]) {
 
     CFE_MissionLib_Set_PubSub_Parameters(&CommandBuffer.BaseObject.Message, &CommandData.PubSub);
 
-    EdsRc = CFE_MissionLib_GetArgumentType(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telecommand_Interface_ID,
+    EdsRc = CFE_MissionLib_GetArgumentType(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telecommand),
             CommandData.Params.Telecommand.TopicId, 1, 1, &CommandData.IntfArg);
     if (EdsRc != CFE_MISSIONLIB_SUCCESS)
     {

--- a/cfecfs/util/tlm_decode.c
+++ b/cfecfs/util/tlm_decode.c
@@ -39,8 +39,8 @@
 #include <string.h> /* memset() */
 
 #include <cfe_mission_cfg.h>
-#include "cfe_sb_eds_typedefs.h"
-#include "cfe_hdr_eds_typedefs.h"
+#include "cfe_sb_eds_datatypes.h"
+#include "cfe_hdr_eds_datatypes.h"
 #include "cfe_mission_eds_parameters.h"
 #include "cfe_mission_eds_interface_parameters.h"
 #include "edslib_displaydb.h"
@@ -50,8 +50,8 @@
 
 #define BASE_SERVER_PORT 1235
 
-CFE_HDR_TelemetryHeader_Buffer_t       LocalBuffer;
-CFE_HDR_TelemetryHeader_PackedBuffer_t NetworkBuffer;
+EdsNativeBuffer_CFE_HDR_TelemetryHeader_t       LocalBuffer;
+EdsPackedBuffer_CFE_HDR_TelemetryHeader_t NetworkBuffer;
 
 static const char *optString = "c:?";
 
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
   unsigned short      Port;
   EdsLib_Id_t      EdsId;
   EdsLib_DataTypeDB_TypeInfo_t TypeInfo;
-  CFE_SB_SoftwareBus_PubSub_Interface_t PubSubParams;
-  CFE_SB_Publisher_Component_t PublisherParams;
+  EdsInterface_CFE_SB_SoftwareBus_PubSub_t PubSubParams;
+  EdsComponent_CFE_SB_Publisher_t PublisherParams;
   char TempBuffer[64];
   int32_t Status;
 
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
     CFE_MissionLib_Get_PubSub_Parameters(&PubSubParams, &LocalBuffer.BaseObject.Message);
     CFE_MissionLib_UnmapPublisherComponent(&PublisherParams, &PubSubParams);
 
-    Status = CFE_MissionLib_GetArgumentType(&CFE_SOFTWAREBUS_INTERFACE, CFE_SB_Telemetry_Interface_ID,
+    Status = CFE_MissionLib_GetArgumentType(&CFE_SOFTWAREBUS_INTERFACE, EDS_INTERFACE_ID(CFE_SB_Telemetry),
             PublisherParams.Telemetry.TopicId, 1, 1, &EdsId);
     if (Status != CFE_MISSIONLIB_SUCCESS)
     {

--- a/tool/src/seds_instance_methods.lua
+++ b/tool/src/seds_instance_methods.lua
@@ -80,23 +80,12 @@ end
 --
 local function debug_print(node)
 
-  local print_tbl
-
-  print_tbl = function(indent,propval)
-    for tk,tv in pairs(propval) do
-      print (indent .. "  [" .. tostring(tk) .. "] => " .. type(tv) .. ":" .. tostring(tv))
-      if (type(tv) == "table") then
-        print_tbl(indent .. "  ", tv)
-      end
-    end
-  end
-
   print ("-- BEGIN INSTANCE PROPERTIES --")
   for i,v in ipairs(node:get_properties()) do
     local propval = node[v]
     print (" [" .. tostring(v) .. "] =>" .. type(propval) .. ":" .. tostring(propval))
     if (type(propval) == "table") then
-      print_tbl("  ", propval)
+      SEDS.debug_print_table("  ", propval)
     end
   end
   print ("-- END INSTANCE PROPERTIES --")

--- a/tool/src/seds_runtime.lua
+++ b/tool/src/seds_runtime.lua
@@ -136,6 +136,79 @@ SEDS.to_macro_name = function(ident)
   return result
 end
 
+local CTYPEDEF_JPHFIX_TABLE = {
+  CONTAINER_DATATYPE = "Struct",
+FLOAT_DATATYPE = "Atom",
+INTEGER_DATATYPE = "Atom",
+BOOLEAN_DATATYPE = "Atom",
+ENUMERATION_DATATYPE = "Enum",
+STRING_DATATYPE = "String",
+ARRAY_DATATYPE = "Array"
+}
+
+local CTYPEDEF_QUALIFIER_TABLE = {
+  GENERIC_TYPE = "Generic_",
+  PARAMETER = "Parameter_",
+  COMMAND = "Command_",
+  ARGUMENT = "Argument_",
+  COMPONENT = "Component_",
+  VARIABLE = "Variable_",
+  DECLARED_INTERFACE = "Interface_",
+  PROVIDED_INTERFACE = "Interface_",
+  REQUIRED_INTERFACE = "Interface_"
+}
+
+-- -------------------------------------------------
+-- Helper function to write an integer typedef
+-- -------------------------------------------------
+SEDS.to_ctype_typedef = function(ref,containment_style)
+
+  local prefix
+  local refstr
+
+  -- this assumes if it is a userdata, then it must be a seds_tree_node object.
+  -- in theory this could accept anything as long as it implements a "get_qualified_name" method.
+  if (type(ref) == "userdata" and ref.entity_type) then
+    if (not containment_style) then
+      prefix = CTYPEDEF_QUALIFIER_TABLE[ref.entity_type]
+    end
+    refstr = ref:get_ctype_basename(containment_style)
+  else
+    refstr = SEDS.to_safe_identifier(ref)
+  end
+
+  if (not prefix) then
+    -- if containment_style was set, then the qualifier should already be embedded within refstr
+    if (containment_style) then
+      prefix = ""
+    else
+      prefix = "DataType_"
+    end
+  end
+
+  return "Eds" .. prefix .. refstr .. "_t"
+end
+
+SEDS.count_results = function(iterator)
+
+  local count = 0
+  for _ in iterator do
+    count = 1 + count
+  end
+
+  return count
+end
+
+SEDS.debug_print_table = function(indent,propval)
+    for tk,tv in pairs(propval) do
+    print (indent .. "  [" .. tostring(tk) .. "] => " .. type(tv) .. ":" .. tostring(tv))
+    if (type(tv) == "table") then
+      SEDS.debug_print_table(indent .. "  ", tv)
+    end
+  end
+end
+
+
 -- -----------------------------------------------------------------------
 -- GLOBAL NODE FILTER FUNCTIONS
 -- In many cases it is necessary to grep through the SEDS node tree


### PR DESCRIPTION
**Describe the contribution**
Implements a bit of paradigm shift in how names of symbols/types are generated, relying on prefixes rather than suffixes.  Using suffixes has an opportunity of name collisions that is not possible when using prefixes.

A separate typedef file maps to the existing type names and thus keeps it compatible with existing code, but only if that typedef file is used.

Fixes #85

**Testing performed**
Build CFE with EDS and sanity check

**Expected behavior changes**
The generated type names are (intentionally) all different and unique from the names used in CFE.   An extra layer of typedef is used to connect the CFE data types to EDS generated types.

**System(s) tested on**
Debian

**Additional context**
The previous model of making the EDS scripts generate type names that exactly match what the CFE code references was getting unsustainable, as there are too many small variations in the code, particularly as more of the CFS apps got EDS-ified.  This is only stable if the code is only/always built with EDS-generated headers.

The intent here is that by adding an extra layer of typedefs between them, this can better adapt to mixtures of EDS and non-EDS environments.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
