### PR TITLE
Fix #90, Init container fields in native object

### DIFF
--- a/edslib/fsw/src/edslib_datatypedb_api.c
+++ b/edslib/fsw/src/edslib_datatypedb_api.c
@@ -603,6 +603,7 @@ int32_t EdsLib_DataTypeDB_InitializeNativeObject(const EdsLib_DatabaseObject_t *
 
     memset(&CtlBlock, 0, sizeof(CtlBlock));
     CtlBlock.NativePtr = UnpackedObj;
+    CtlBlock.RecomputeFields = EDSLIB_DATATYPEDB_RECOMPUTE_FIXEDVALUE | EDSLIB_DATATYPEDB_RECOMPUTE_LENGTH;
 
     EDSLIB_RESET_ITERATOR_FROM_EDSID(IteratorState, EdsId);
     Status = EdsLib_DataTypeIterator_Impl(GD, &IteratorState.Cb);
@@ -701,5 +702,3 @@ int32_t EdsLib_DataTypeDB_IdentifyBuffer(const EdsLib_DatabaseObject_t *GD, EdsL
 
     return Status;
 }
-
-


### PR DESCRIPTION
**Describe the contribution**
The EdsLib_DataTypeDB_InitializeNativeObject() should be setting the calculated fields in the native object.  This does not currently include error control as that is more intensive to calculate and is generally only relevant to encoded objects.

Fixes #90

**Testing performed**
Verified object is being initialized correctly

**Expected behavior changes**
Length field is set correctly

**System(s) tested on**
Debian

**Additional context**
Found as part of scripting demo

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
