### PR TITLE
Fix #96, check for nil value before reading min/max

### DIFF
--- a/cfecfs/missionlib/eds/91-write_cosmos_txt.lua
+++ b/cfecfs/missionlib/eds/91-write_cosmos_txt.lua
@@ -131,13 +131,17 @@ write_cosmos_lineitem = function(output,line_writer,entry,qual_prefix,descr)
 
     -- This only handles integers
     if (entry.resolved_range) then
-      attribs.min = entry.resolved_range.min.value
-      if (not entry.resolved_range.min.inclusive) then
-        attribs.min = attribs.min + 1
+      if (entry.resolved_range.min) then
+        attribs.min = entry.resolved_range.min.value
+        if (not entry.resolved_range.min.inclusive) then
+          attribs.min = attribs.min + 1
+        end
       end
-      attribs.max = entry.resolved_range.max.value
-      if (not entry.resolved_range.max.inclusive) then
-        attribs.max = attribs.max - 1
+      if (entry.resolved_range.max) then
+        attribs.max = entry.resolved_range.max.value
+        if (not entry.resolved_range.max.inclusive) then
+          attribs.max = attribs.max - 1
+        end
       end
     end
   end


### PR DESCRIPTION
**Describe the contribution**
If the single-ended limit attributes are used in XML, it is possible to have the resolved_range set but only one of min or max, not both. The non-specified limit will be nil.  The script needs to handle this.

Fixes #96

**Testing performed**
Build with EDS containing a AtMost/AtLeast type of attribute (single-ended)

**Expected behavior changes**
Successfully builds

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.