### PR TITLE
Fix #100, use the PyBytes constructor

### DIFF
--- a/edslib/python/src/edslib_python_packedobject.c
+++ b/edslib/python/src/edslib_python_packedobject.c
@@ -187,15 +187,11 @@ static PyObject *EdsLib_Python_PackedObjectType_new(PyTypeObject *objtype, PyObj
 
     if (contentdata_src != NULL)
     {
-        result = (PyBytesObject*)objtype->tp_alloc(objtype, contentdata_size);
+        result = (PyBytesObject*)PyBytes_FromStringAndSize(contentdata_src, contentdata_size);
         if (result != NULL)
         {
-            char *contentdata_dst = PyBytes_AS_STRING(result);
-            Py_MEMCPY(contentdata_dst,
-                    contentdata_src,
-                    contentdata_size);
-            contentdata_dst[contentdata_size] = 0;
-            result->ob_shash = -1;
+            /* This identifies it as an instance of the EdsLib.PackedObject type, as opposed to a vanilla bytes object */
+            Py_SET_TYPE(result, objtype);
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**
Using the PyBytes_FromStringAndSize API call will initialize the ob_shash field as appropriate for the version of Python in use.  The only issue is that it has to set the type appropriately after the fact, to indicate it is an instance of the EdsLib.PackedObject type.

Fixes #100

**Testing performed**
Build EdsLib python module

**Expected behavior changes**
No warning about access to the deprecated field

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
