### PR TITLE
edslib runtime lib improved portability

### DIFF
--- a/edslib/fsw/src/edslib_binding_objects.c
+++ b/edslib/fsw/src/edslib_binding_objects.c
@@ -34,13 +34,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <setjmp.h>
-#include <unistd.h>
 #include <errno.h>
 #include <time.h>
 #include <ctype.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "edslib_id.h"
 #include "edslib_datatypedb.h"

--- a/edslib/fsw/src/edslib_database_ops.c
+++ b/edslib/fsw/src/edslib_database_ops.c
@@ -36,7 +36,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_datatypedb_api.c
+++ b/edslib/fsw/src/edslib_datatypedb_api.c
@@ -37,7 +37,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_datatypedb_constraints.c
+++ b/edslib/fsw/src/edslib_datatypedb_constraints.c
@@ -35,7 +35,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_datatypedb_lookup.c
+++ b/edslib/fsw/src/edslib_datatypedb_lookup.c
@@ -36,7 +36,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_datatypedb_pack_unpack.c
+++ b/edslib/fsw/src/edslib_datatypedb_pack_unpack.c
@@ -51,7 +51,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdint.h>

--- a/edslib/fsw/src/edslib_displaydb_api.c
+++ b/edslib/fsw/src/edslib_displaydb_api.c
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_displaydb_iterator.c
+++ b/edslib/fsw/src/edslib_displaydb_iterator.c
@@ -33,7 +33,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_displaydb_locate.c
+++ b/edslib/fsw/src/edslib_displaydb_locate.c
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_displaydb_lookup.c
+++ b/edslib/fsw/src/edslib_displaydb_lookup.c
@@ -33,7 +33,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_displaydb_stringconv.c
+++ b/edslib/fsw/src/edslib_displaydb_stringconv.c
@@ -49,19 +49,19 @@ static int32_t EdsLib_Internal_StringCompare_IgnoreCase(const char *String1,
 {
     uint32_t Index  = 0U;
     int32_t  Result = 0;
-    int32_t  Char1  = 0;
-    int32_t  Char2  = 0;
+    int      Char1;
+    int      Char2;
 
     while (Result == 0)
     {
-        if (String1[Index] == '\0' || String2[Index] == '\0')
+        Char1 = (int)String1[Index];
+        Char2 = (int)String2[Index];
+
+        if (Char1 == '\0' || Char2 == '\0')
         {
-            Result = String1[Index] - String2[Index];
+            Result = Char1 - Char2;
             break;
         }
-
-        Char1 = (int32_t)String1[Index];
-        Char2 = (int32_t)String2[Index];
 
         /* Convert characters to lower case if they're alphabetical */
         if (isalpha(Char1))

--- a/edslib/fsw/src/edslib_displaydb_stringconv.c
+++ b/edslib/fsw/src/edslib_displaydb_stringconv.c
@@ -32,12 +32,55 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <strings.h>
 #include <ctype.h>
 #include <limits.h>
 
 #include <stdint.h>
 #include "edslib_internal.h"
+
+
+/*----------------------------------------------------------------
+ * 
+ * EdsLib local helper function
+ *
+ *----------------------------------------------------------------*/
+static int32_t EdsLib_Internal_StringCompare_IgnoreCase(const char *String1,
+                                                        const char *String2)
+{
+    uint32_t Index  = 0U;
+    int32_t  Result = 0;
+    int32_t  Char1  = 0;
+    int32_t  Char2  = 0;
+
+    while (Result == 0)
+    {
+        if (String1[Index] == '\0' || String2[Index] == '\0')
+        {
+            Result = String1[Index] - String2[Index];
+            break;
+        }
+
+        Char1 = (int32_t)String1[Index];
+        Char2 = (int32_t)String2[Index];
+
+        /* Convert characters to lower case if they're alphabetical */
+        if (isalpha(Char1))
+        {
+            Char1 = tolower(Char1);
+        }
+
+        if (isalpha(Char2))
+        {
+            Char2 = tolower(Char2);
+        }
+
+        Result = Char1 - Char2;
+
+        ++Index;
+    }
+
+    return Result;
+}
 
 /*----------------------------------------------------------------
  *
@@ -419,22 +462,22 @@ int32_t EdsLib_DisplayScalarConv_FromString_Impl(const EdsLib_DataTypeDB_Entry_t
                 {
                     /* typically TRUE/FALSE, also accept YES/NO or 0/1 */
                     const char *EndPtr = SrcString;
-                    if (strcasecmp(SrcString, "true") == 0)
+                    if (EdsLib_Internal_StringCompare_IgnoreCase(SrcString, "true") == 0)
                     {
                         EndPtr                             += 4;
                         NumberBuffer.Value.UnsignedInteger  = 1;
                     }
-                    else if (strcasecmp(SrcString, "false") == 0)
+                    else if (EdsLib_Internal_StringCompare_IgnoreCase(SrcString, "false") == 0)
                     {
                         EndPtr                             += 4;
                         NumberBuffer.Value.UnsignedInteger  = 0;
                     }
-                    else if (strcasecmp(SrcString, "yes") == 0)
+                    else if (EdsLib_Internal_StringCompare_IgnoreCase(SrcString, "yes") == 0)
                     {
                         EndPtr                             += 3;
                         NumberBuffer.Value.UnsignedInteger  = 1;
                     }
-                    else if (strcasecmp(SrcString, "no") == 0)
+                    else if (EdsLib_Internal_StringCompare_IgnoreCase(SrcString, "no") == 0)
                     {
                         EndPtr                             += 2;
                         NumberBuffer.Value.UnsignedInteger  = 0;

--- a/edslib/fsw/src/edslib_global_api.c
+++ b/edslib/fsw/src/edslib_global_api.c
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_intfdb_api.c
+++ b/edslib/fsw/src/edslib_intfdb_api.c
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/edslib/fsw/src/edslib_intfdb_lookup.c
+++ b/edslib/fsw/src/edslib_intfdb_lookup.c
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 


### PR DESCRIPTION
**Describe the contribution**
Removed non standard C library headers, replaced `strcasecmp` with local helper function.

**Testing performed**
Built on Windows using VS2026, cmake and MSVC
Built on Linux using cmake and gcc

Tested new local helper against strcasecmp. See end of PR for list of comparisons
Checked with CppCheck with flags `--enable=all --check-level=exhaustive`

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Windows 11 Home 25H2, build 26200.8246
Xubuntu 24.04.3 LTS x86_64 VMWare Virtual machine, kernel 6.17.0-22-generic

**Contributor Info - All information REQUIRED for consideration of pull request**
Mathias Ingeman Behrens, Personal

## Tested comparisons
1. "abc", "ABC"
2. "a1A", "A1a"
3. "123", "123"
4. "", ""
5. "abc", "abd"
6. "abc", "cba"
7. "1", "1234"
8. "1234", "1"
9. "trU", "true"
10. "truee", "true"