### PR TITLE
Fix #115, add state outputs for COSMOS

### DIFF
--- a/cfecfs/missionlib/eds/91-write_cosmos_txt.lua
+++ b/cfecfs/missionlib/eds/91-write_cosmos_txt.lua
@@ -57,11 +57,25 @@ local append_qual_prefix = function(old_prefix,add_prefix)
 end
 
 -- -------------------------------------------------------------------------
+-- Helper function: Write the enumeration labels associated with a lineitem (STATE tags)
+-- -------------------------------------------------------------------------
+write_cosmos_states = function(output,attribs)
+  if (attribs.labels) then
+    output:start_group()
+    for label in attribs.labels:iterate_subtree("ENUMERATION_ENTRY") do
+      output:write(string.format("STATE %s %d",string.upper(label.name),label.value))
+    end
+    output:end_group()
+  end
+end
+
+-- -------------------------------------------------------------------------
 -- Helper function: Write a single line-item to a TLM definition (APPEND_ITEM)
 -- -------------------------------------------------------------------------
 write_cosmos_tlm_lineitem = function(output,attribs)
 
   output:write(string.format("APPEND_ITEM %s %d %s \"%s\"", attribs.name, attribs.bitsize, attribs.ctype, attribs.descr))
+  write_cosmos_states(output,attribs)
 
 end
 
@@ -101,6 +115,7 @@ write_cosmos_cmd_lineitem = function(output,attribs)
     output:write(string.format("APPEND_PARAMETER %s %d %s %s %s %d \"%s\"",
       attribs.name, attribs.bitsize, attribs.ctype, min, max, attribs.defaultval or 0, attribs.descr or ""))
 
+    write_cosmos_states(output,attribs)
   end
 
 end
@@ -158,6 +173,11 @@ write_cosmos_lineitem = function(output,line_writer,entry,qual_prefix,descr)
     attribs.ctype = "FLOAT"
   elseif (entry.entity_type == "BOOLEAN_DATATYPE" or SEDS.index_datatype_filter(entry)) then
     attribs.ctype = (entry.is_signed and "INT") or "UINT"
+
+    -- collect the labels if this is an enum
+    if (entry.entity_type == "ENUMERATION_DATATYPE") then
+      attribs.labels = entry:find_first("ENUMERATION_LIST")
+    end
 
     -- This only handles integers
     if (entry.resolved_range) then


### PR DESCRIPTION
**Describe the contribution**
Add "STATE" indications in COSMOS

Fixes #115

**Testing performed**
Check COSMOS output

**Expected behavior changes**
Example of CF reset command in generated file:
```
<%= cfs_cmd_hdr(target_name, 'CF_CMD_RESET_COUNTERS', 1, "Resets HK TLM parent and child task counters") %>
   APPEND_PARAMETER RESET_TYPE 8 UINT 0 4 0 "What to reset"
      STATE ALL 0
      STATE COMMAND 1
      STATE FAULT 2
      STATE UP 3
      STATE DOWN 4
```

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

**For members of the cFS Team**
Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
- [Tools Code Change](?expand=1&template=tools_code_change.md)
- [Workflows Change](?expand=1&template=workflows_change.md)
